### PR TITLE
Add firmware status entity and relays

### DIFF
--- a/custom_components/enphase_envoy/__init__.py
+++ b/custom_components/enphase_envoy/__init__.py
@@ -20,6 +20,7 @@ from .const import (
     DOMAIN,
     NAME,
     PLATFORMS,
+    BINARY_SENSORS,
     SENSORS,
     CONF_USE_ENLIGHTEN,
     CONF_SERIAL,
@@ -59,6 +60,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 raise ConfigEntryAuthFailed from err
             except httpx.HTTPError as err:
                 raise UpdateFailed(f"Error communicating with API: {err}") from err
+
+            for description in BINARY_SENSORS:
+                if description.key == "relays":
+                    data[description.key] = await envoy_reader.relay_status()
+
+                elif description.key == 'firmware':
+                    data[description.key] = await envoy_reader.firmware_data()
 
             for description in SENSORS:
                 if description.key == "inverters":

--- a/custom_components/enphase_envoy/const.py
+++ b/custom_components/enphase_envoy/const.py
@@ -156,6 +156,16 @@ BINARY_SENSORS = (
         name="Grid Status",
         device_class=BinarySensorDeviceClass.CONNECTIVITY,
     ),
+    BinarySensorEntityDescription(
+        key="relays",
+        name="Relay",
+        device_class=BinarySensorDeviceClass.POWER,
+    ),
+    BinarySensorEntityDescription(
+        key="firmware",
+        name="Firmware",
+        device_class=BinarySensorDeviceClass.UPDATE,
+    ),
 )
 
 BATTERY_ENERGY_DISCHARGED_SENSOR = SensorEntityDescription(


### PR DESCRIPTION
I have two relays in my setup, which are also available through this newly discovered endpoint 😄 

And i already had a custom entity for firmware status of the envoy, so i just added this as well.

Unfortunately, the relays only report back if they are open/closed (and no voltage/hertz stats), but at least it's something.

The relays appear in both the pcu (where inverters live as well), and in the nsrb output, so they had to be filtered out in the `inverters_status` method.

Some example output from my env:
```json
{
    "counters": {
        "pcu": {
            "expected": 14,
            "discovered": 14,
            "ctrlsTotal": 14,
            "ctrlsGone": 0,
            "ctrlsCommunicating": 14,
            "chansTotal": 14,
            "chansRecent": 14,
            "chansProducing": 14
        },
        "acb": {
            "expected": 0,
            "discovered": 0,
            "ctrlsTotal": 0,
            "ctrlsGone": 0,
            "ctrlsCommunicating": 0,
            "chansTotal": 0,
            "chansRecent": 0,
            "chansProducing": 0
        },
        "nsrb": {
            "expected": 2,
            "discovered": 2,
            "ctrlsTotal": 2,
            "ctrlsGone": 0,
            "ctrlsCommunicating": 2,
            "chansTotal": 2,
            "chansRecent": 2,
            "chansProducing": 0
        },
        "pld": {
            "expected": 16,
            "discovered": 16,
            "ctrlsTotal": 16,
            "ctrlsGone": 0,
            "ctrlsCommunicating": 16,
            "chansTotal": 16,
            "chansRecent": 16,
            "chansProducing": 14
        },
        "esub": {
            "expected": 0,
            "discovered": 0,
            "ctrlsTotal": 0,
            "ctrlsGone": 0,
            "ctrlsCommunicating": 0,
            "chansTotal": 0,
            "chansRecent": 0,
            "chansProducing": 0
        }
    },
    "pcu": {
        "fields": ["serialNumber", "devType", "communicating", "recent", "producing", "reportDate", "temperature", "dcVoltageINmV", "dcCurrentINmA", "acVoltageINmV", "acPowerINmW"],
        "values": [
            ["123456789010", 1, true, true, true, 1683023261, 34, 31071, 3377, 236976, 198129],
            ["123456789012", 1, true, true, true, 1683023263, 28, 31204, 3397, 236576, 199061],
            ["123456789750", 1, true, true, true, 1683023265, 29, 31344, 2762, 237104, 186158],
            ["123456789983", 1, true, true, true, 1683023265, 34, 31069, 3382, 237048, 199176],
            ["123456789520", 1, true, true, true, 1683023268, 29, 31312, 2737, 237312, 184320],
            ["123456789983", 1, true, true, true, 1683023270, 25, 31507, 3192, 237240, 195689],
            ["123456789521", 1, true, true, true, 1683023271, 25, 31504, 3242, 237616, 197302],
            ["123456789669", 1, true, true, true, 1683023273, 25, 31425, 3252, 237520, 198788],
            ["123456789748", 1, true, true, true, 1683023275, 25, 31418, 3231, 236768, 197134],
            ["123456789985", 1, true, true, true, 1683023276, 26, 31435, 2713, 237184, 184904],
            ["123456789285", 1, true, true, true, 1683023279, 25, 31385, 3144, 237296, 197203],
            ["123456789246", 1, true, true, true, 1683023281, 25, 31399, 3197, 238328, 198656],
            ["123456789590", 1, true, true, true, 1683023280, 26, 31310, 3082, 238136, 196538],
            ["123456789862", 1, true, true, true, 1683023284, 27, 31653, 2714, 237728, 188057],
            ["123456789177", 12, true, true, false, 1683023285, 0, 0, 0, 0, 0],
            ["123456789944", 12, true, true, false, 1683023287, 0, 0, 0, 0, 0]
        ]
    },
    "acb": {
        "fields": ["serialNumber", "SOC", "minCellTemp", "maxCellTemp", "capacity", "totVoltage", "sleepEnabled", "sleepMinSoc", "sleepMaxSoc"],
        "values": []
    },
    "nsrb": {
        "fields": ["serialNumber", "relay", "forced", "reason_code", "reason", "line-count", "line1-connected", "line2-connected", "line3-connected"],
        "values": [
            ["123456789177", "closed", false, -1, "ok", 1, true, false, false],
            ["123456789944", "closed", false, -1, "ok", 1, true, false, false]
        ]
    }
}
```