### PR TITLE
Prevent negative production values, for small negative

### DIFF
--- a/custom_components/enphase_envoy/__init__.py
+++ b/custom_components/enphase_envoy/__init__.py
@@ -26,9 +26,9 @@ from .const import (
     PHASE_SENSORS,
     CONF_SERIAL,
     READER,
+    DEFAULT_SCAN_INTERVAL,
 )
 
-SCAN_INTERVAL = timedelta(seconds=60)
 STORAGE_KEY = "envoy"
 STORAGE_VERSION = 1
 
@@ -39,6 +39,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Enphase Envoy from a config entry."""
 
     config = entry.data
+    options = entry.options
     name = config[CONF_NAME]
 
     # Setup persistent storage, to save tokens between home assistant restarts
@@ -51,6 +52,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         inverters=True,
         enlighten_serial_num=config[CONF_SERIAL],
         store=store,
+        disable_negative_production=options.get("disable_negative_production", False),
     )
     await envoy_reader._sync_store()
 
@@ -148,7 +150,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         _LOGGER,
         name=f"envoy {name}",
         update_method=async_update_data,
-        update_interval=SCAN_INTERVAL,
+        update_interval=timedelta(
+            seconds=options.get("time_between_update", DEFAULT_SCAN_INTERVAL)
+        ),
     )
 
     try:

--- a/custom_components/enphase_envoy/const.py
+++ b/custom_components/enphase_envoy/const.py
@@ -30,6 +30,8 @@ COORDINATOR = "coordinator"
 NAME = "name"
 READER = "reader"
 
+DEFAULT_SCAN_INTERVAL = 60  # default in seconds
+
 CONF_SERIAL = "serial"
 
 SENSORS = (

--- a/custom_components/enphase_envoy/strings.json
+++ b/custom_components/enphase_envoy/strings.json
@@ -21,5 +21,19 @@
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     }
+  },
+  "options": {
+    "step": {
+      "user": {
+        "title": "Envoy options",
+        "data": {
+          "disable_negative_production": "Disable negative production values",
+          "time_between_update": "Minimum time between entity updates [s]"
+        },
+        "data_description": {
+          "time_between_update": "This interval only applies to the polling interval (not on the live updates)"
+        }
+      }
+    }
   }
 }

--- a/custom_components/enphase_envoy/translations/en.json
+++ b/custom_components/enphase_envoy/translations/en.json
@@ -21,5 +21,19 @@
         "description": "Enter the hostname/ip and serial of your Envoy. Use your Enlighten Installer account credentials."
       }
     }
+  },
+  "options": {
+    "step": {
+      "user": {
+        "title": "Envoy options",
+        "data": {
+          "disable_negative_production": "Disable negative production values",
+          "time_between_update": "Minimum time between entity updates [s]"
+        },
+        "data_description": {
+          "time_between_update": "This interval only applies to the polling interval (not on the live updates)"
+        }
+      }
+    }
   }
 }

--- a/custom_components/enphase_envoy/translations/nl.json
+++ b/custom_components/enphase_envoy/translations/nl.json
@@ -21,5 +21,19 @@
                 "description": "Voer de hostname/ip en serienummer van je Envoy in. Gebruik je Enlighten installer account gegevens."
             }
         }
+    },
+    "options": {
+      "step": {
+        "user": {
+          "title": "Envoy opties",
+          "data": {
+            "disable_negative_production": "Voorkom negatieve productie waardes",
+            "time_between_update": "Minimum tijd tussen entity updates [s]"
+          },
+          "data_description": {
+            "time_between_update": "Dit interval is alleen van toepassing voor het pollen van URLs"
+          }
+        }
+      }
     }
 }


### PR DESCRIPTION
When the CT is logically wired behind the Relay, it will measure about 3.5 watts of usage per relay. So a small relay usage when the sun is down should not be counted as real production value, but just report a production value of 0 watts.