### PR TITLE
Adding option to read realtime data from envoy using /stream/meter endpoint

### DIFF
--- a/custom_components/enphase_envoy/__init__.py
+++ b/custom_components/enphase_envoy/__init__.py
@@ -1,20 +1,31 @@
 """The Enphase Envoy integration."""
 from __future__ import annotations
 
+import asyncio
+from contextlib import suppress
 from datetime import timedelta
 import logging
+import time
 
 import async_timeout
-from .envoy_reader import EnvoyReader
+from .envoy_reader import EnvoyReader, StreamData
 import httpx
 from numpy import isin
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PASSWORD, CONF_USERNAME
-from homeassistant.core import HomeAssistant
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_NAME,
+    CONF_PASSWORD,
+    CONF_USERNAME,
+    EVENT_HOMEASSISTANT_STOP,
+)
+from homeassistant.core import HomeAssistant, callback, CoreState, Event
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.helpers.storage import Store
+from homeassistant.util import Throttle
+
 
 from .const import (
     COORDINATOR,
@@ -27,6 +38,8 @@ from .const import (
     CONF_SERIAL,
     READER,
     DEFAULT_SCAN_INTERVAL,
+    DEFAULT_REALTIME_UPDATE_THROTTLE,
+    LIVE_UPDATEABLE_ENTITIES,
 )
 
 STORAGE_KEY = "envoy"
@@ -38,6 +51,7 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Enphase Envoy from a config entry."""
 
+    task = None
     config = entry.data
     options = entry.options
     name = config[CONF_NAME]
@@ -107,13 +121,21 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
             for description in PHASE_SENSORS:
                 if description.key.startswith("production_"):
-                    data[description.key] = await envoy_reader.production_phase(
-                        description.key
-                    )
+                    if envoy_reader.is_receiving_realtime_data:
+                        # do not update, use current value
+                        data[description.key] = coordinator.data[description.key]
+                    else:
+                        data[description.key] = await envoy_reader.production_phase(
+                            description.key
+                        )
                 elif description.key.startswith("consumption_"):
-                    data[description.key] = await envoy_reader.consumption_phase(
-                        description.key
-                    )
+                    if envoy_reader.is_receiving_realtime_data:
+                        # do not update, use current value
+                        data[description.key] = coordinator.data[description.key]
+                    else:
+                        data[description.key] = await envoy_reader.consumption_phase(
+                            description.key
+                        )
                 elif description.key.startswith("daily_production_"):
                     data[description.key] = await envoy_reader.daily_production_phase(
                         description.key
@@ -131,9 +153,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                         description.key
                     ] = await envoy_reader.lifetime_consumption_phase(description.key)
                 elif description.key.startswith("voltage_"):
-                    data[description.key] = await envoy_reader.voltage_phase(
-                        description.key
-                    )
+                    if envoy_reader.is_receiving_realtime_data:
+                        # do not update, use current value
+                        data[description.key] = coordinator.data[description.key]
+                    else:
+                        data[description.key] = await envoy_reader.voltage_phase(
+                            description.key
+                        )
 
             data["grid_status"] = await envoy_reader.grid_status()
             data["production_power"] = await envoy_reader.production_power()
@@ -175,14 +201,92 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         NAME: name,
         READER: envoy_reader,
     }
+    live_entities = hass.data[DOMAIN][entry.entry_id].setdefault(
+        LIVE_UPDATEABLE_ENTITIES, {}
+    )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
+    # Finally, start measuring production counters
+    time_between_realtime_updates = timedelta(
+        seconds=options.get(
+            "realtime_update_throttle", DEFAULT_REALTIME_UPDATE_THROTTLE
+        ),
+    )
+
+    @Throttle(time_between_realtime_updates)
+    def update_production_meters(streamdata: StreamData):
+        new_data = {}
+        for phase in ["l1", "l2", "l3"]:
+            production_watts = envoy_reader.process_production_value(
+                streamdata.production[phase].watts
+            )
+            new_data.update(
+                {
+                    "production_" + phase: production_watts,
+                    "voltage_" + phase: streamdata.production[phase].volt,
+                    "consumption_" + phase: streamdata.consumption[phase].watts,
+                }
+            )
+
+        for key, value in new_data.items():
+            if live_entities.get(key, False) and coordinator.data.get(key) != value:
+                # Update the value in the coordinator
+                coordinator.data[key] = value
+
+                # Let hass know the data is updated
+                live_entities[key].async_write_ha_state()
+
+    async def read_realtime_updates() -> None:
+        while (
+            hass.state == CoreState.not_running
+            or hass.is_running
+            and options.get("enable_realtime_updates", False)
+        ):
+            result = await envoy_reader.stream_reader(
+                meter_callback=update_production_meters
+            )
+            if result == False:
+                # If result is False, then we are done reconnecting
+                _LOGGER.warning(
+                    "Reading /stream/meter failed, stopping realtime updates"
+                )
+                return
+
+            _LOGGER.warning("Re-connecting /stream/meter")
+            # throttle reconnect attempts
+            await asyncio.sleep(30)
+
+    if options.get("enable_realtime_updates", False):
+        # Setup a home assistant task (that will never die...)
+        _LOGGER.debug("Starting loop for /stream/meter")
+        task = asyncio.create_task(read_realtime_updates())
+
+    @callback
+    async def _async_stop(_: Event) -> None:
+        _LOGGER.debug("Stopping loop for /stream/meter")
+        task.cancel()
+
+    # Make sure task is cancelled on shutdown (or tests complete)
+    entry.async_on_unload(
+        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _async_stop)
+    )
+
+    # Save the task to be able to cancel it when unloading
+    hass.data[DOMAIN][entry.entry_id]["realtime_loop"] = task
     return True
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
+
+    if task := hass.data[DOMAIN][entry.entry_id].get("realtime_loop", False):
+        _LOGGER.debug("Stopping loop for /stream/meter")
+        task.cancel()
+
+        with suppress(asyncio.CancelledError):
+            await task
+
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
         hass.data[DOMAIN].pop(entry.entry_id)

--- a/custom_components/enphase_envoy/config_flow.py
+++ b/custom_components/enphase_envoy/config_flow.py
@@ -21,7 +21,12 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.exceptions import HomeAssistantError
 
-from .const import DOMAIN, CONF_SERIAL, DEFAULT_SCAN_INTERVAL
+from .const import (
+    DOMAIN,
+    CONF_SERIAL,
+    DEFAULT_SCAN_INTERVAL,
+    DEFAULT_REALTIME_UPDATE_THROTTLE,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -223,6 +228,16 @@ class EnvoyOptionsFlowHandler(config_entries.OptionsFlow):
                     "disable_negative_production", False
                 ),
             ): bool,
+            vol.Optional(
+                "enable_realtime_updates",
+                default=self.config_entry.options.get("enable_realtime_updates", False),
+            ): bool,
+            vol.Optional(
+                "realtime_update_throttle",
+                default=self.config_entry.options.get(
+                    "realtime_update_throttle", DEFAULT_REALTIME_UPDATE_THROTTLE
+                ),
+            ): vol.All(vol.Coerce(int), vol.Range(min=0)),
         }
         return self.async_show_form(step_id="user", data_schema=vol.Schema(schema))
 

--- a/custom_components/enphase_envoy/const.py
+++ b/custom_components/enphase_envoy/const.py
@@ -31,8 +31,11 @@ NAME = "name"
 READER = "reader"
 
 DEFAULT_SCAN_INTERVAL = 60  # default in seconds
+DEFAULT_REALTIME_UPDATE_THROTTLE = 10
 
 CONF_SERIAL = "serial"
+
+LIVE_UPDATEABLE_ENTITIES = "live-update-entities"
 
 SENSORS = (
     SensorEntityDescription(

--- a/custom_components/enphase_envoy/sensor.py
+++ b/custom_components/enphase_envoy/sensor.py
@@ -23,6 +23,7 @@ from .const import (
     SENSORS,
     ICON,
     PHASE_SENSORS,
+    LIVE_UPDATEABLE_ENTITIES,
 )
 
 
@@ -35,6 +36,7 @@ async def async_setup_entry(
     data = hass.data[DOMAIN][config_entry.entry_id]
     coordinator = data[COORDINATOR]
     name = data[NAME]
+    live_entities = data[LIVE_UPDATEABLE_ENTITIES]
 
     entities = []
     for sensor_description in SENSORS:
@@ -162,17 +164,16 @@ async def async_setup_entry(
             continue
 
         entity_name = f"{name} {sensor_description.name}"
-        entities.append(
-            CoordinatedEnvoyEntity(
-                sensor_description,
-                entity_name,
-                name,
-                config_entry.unique_id,
-                None,
-                coordinator,
-                config_entry.data[CONF_HOST],
-            )
+        live_entities[sensor_description.key] = CoordinatedEnvoyEntity(
+            sensor_description,
+            entity_name,
+            name,
+            config_entry.unique_id,
+            None,
+            coordinator,
+            config_entry.data[CONF_HOST],
         )
+        entities.append(live_entities[sensor_description.key])
 
     async_add_entities(entities)
 

--- a/custom_components/enphase_envoy/strings.json
+++ b/custom_components/enphase_envoy/strings.json
@@ -27,10 +27,13 @@
       "user": {
         "title": "Envoy options",
         "data": {
+          "enable_realtime_updates": "Enable realtime updates (only for metered envoys)",
+          "realtime_update_throttle": "Minimum time between realtime entity updates [s]",
           "disable_negative_production": "Disable negative production values",
           "time_between_update": "Minimum time between entity updates [s]"
         },
         "data_description": {
+          "realtime_update_throttle": "Only applies to realtime updates (to preventing any overload on the system)",
           "time_between_update": "This interval only applies to the polling interval (not on the live updates)"
         }
       }

--- a/custom_components/enphase_envoy/translations/en.json
+++ b/custom_components/enphase_envoy/translations/en.json
@@ -27,10 +27,13 @@
       "user": {
         "title": "Envoy options",
         "data": {
+          "enable_realtime_updates": "Enable realtime updates (only for metered envoys)",
+          "realtime_update_throttle": "Minimum time between realtime entity updates [s]",
           "disable_negative_production": "Disable negative production values",
           "time_between_update": "Minimum time between entity updates [s]"
         },
         "data_description": {
+          "realtime_update_throttle": "Only applies to realtime updates (to preventing any overload on the system)",
           "time_between_update": "This interval only applies to the polling interval (not on the live updates)"
         }
       }

--- a/custom_components/enphase_envoy/translations/nl.json
+++ b/custom_components/enphase_envoy/translations/nl.json
@@ -27,10 +27,13 @@
         "user": {
           "title": "Envoy opties",
           "data": {
+            "enable_realtime_updates": "Gebruik real-time updates (werkt alleen met metered envoys)",
+            "realtime_update_throttle": "Minimale tijd tussen real-time updates [s]",
             "disable_negative_production": "Voorkom negatieve productie waardes",
             "time_between_update": "Minimum tijd tussen entity updates [s]"
           },
           "data_description": {
+            "realtime_update_throttle": "Dit interval is van toepassing op real-time updates (om eventuele overload met updates te voorkomen)",
             "time_between_update": "Dit interval is alleen van toepassing voor het pollen van URLs"
           }
         }


### PR DESCRIPTION
This can be turned on using configuration, and is disabled by default It will only update the phase sensors entities, as these sensors are fed back from the endpoint. The default consumption/production/etc entities are still polled and updated every minute (unless configured otherwise)

Also implemented a interval/throttle to prevent a entity update overload for some systems (took this example from the dsmr reader component)

It will only update the phase sensors that actually hold some data.

It works for me (with 1phase metered), and it should not break non-metered envoys (but i could not fully test this)