### PR TITLE
Add configuration option to not collect data that requires installer or DIY account

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 This is a HACS custom integration for enphase envoys with firmware version 7.X.
 
-▶ To be used with your installer or DIY account. (Most of the functionality won't be available when using a Home Owner account.)
+▶ To be used with your installer or DIY account. (Most of the functionality won't be available when using a Home Owner account, to disable the collection of these use the setting to not collect data that requires installer or DIY accounts.)
 
 ⚠ Some older Envoy firmware versions exposed the needed API endpoints without proper authentication. This has been fixed by Enphase and they pushed an update to the Envoys. If you are using this integration with a Home Owner account you probably lost most of the functionality since.
 
@@ -32,6 +32,7 @@ Or follow these steps:
 2. Add this repository as a [custom integration repository](https://hacs.xyz/docs/faq/custom_repositories) in HACS
 4. Restart home assistant
 5. Add the integration through the home assistant configuration flow
+6. If you only have a Home owner account use the configureation option to not collect data that requires installer or DIY enphase account and relaod the integration
 
 [releases-shield]: https://img.shields.io/github/v/release/vincentwolsink/home_assistant_enphase_envoy_installer.svg?style=for-the-badge
 [releases]: https://github.com/vincentwolsink/home_assistant_enphase_envoy_installer/releases

--- a/custom_components/enphase_envoy/__init__.py
+++ b/custom_components/enphase_envoy/__init__.py
@@ -67,6 +67,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         enlighten_serial_num=config[CONF_SERIAL],
         store=store,
         disable_negative_production=options.get("disable_negative_production", False),
+        disable_installer_account_use=options.get("disable_installer_account_use", False),
     )
     await envoy_reader._sync_store()
 

--- a/custom_components/enphase_envoy/__init__.py
+++ b/custom_components/enphase_envoy/__init__.py
@@ -68,7 +68,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         enlighten_serial_num=config[CONF_SERIAL],
         store=store,
         disable_negative_production=options.get("disable_negative_production", False),
-        disable_installer_account_use=options.get(DISABLE_INSTALLER_ACCOUNT_USE,config[DISABLE_INSTALLER_ACCOUNT_USE]),
+        disable_installer_account_use=options.get(DISABLE_INSTALLER_ACCOUNT_USE,config.get(DISABLE_INSTALLER_ACCOUNT_USE,False)),
     )
     await envoy_reader._sync_store()
 

--- a/custom_components/enphase_envoy/__init__.py
+++ b/custom_components/enphase_envoy/__init__.py
@@ -68,7 +68,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         enlighten_serial_num=config[CONF_SERIAL],
         store=store,
         disable_negative_production=options.get("disable_negative_production", False),
-        disable_installer_account_use=options.get(DISABLE_INSTALLER_ACCOUNT_USE,config.get(DISABLE_INSTALLER_ACCOUNT_USE,False)),
+        disable_installer_account_use=options.get(
+            DISABLE_INSTALLER_ACCOUNT_USE,
+            config.get(DISABLE_INSTALLER_ACCOUNT_USE, False),
+        ),
     )
     await envoy_reader._sync_store()
 

--- a/custom_components/enphase_envoy/__init__.py
+++ b/custom_components/enphase_envoy/__init__.py
@@ -40,6 +40,7 @@ from .const import (
     DEFAULT_SCAN_INTERVAL,
     DEFAULT_REALTIME_UPDATE_THROTTLE,
     LIVE_UPDATEABLE_ENTITIES,
+    DISABLE_INSTALLER_ACCOUNT_USE,
 )
 
 STORAGE_KEY = "envoy"
@@ -67,7 +68,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         enlighten_serial_num=config[CONF_SERIAL],
         store=store,
         disable_negative_production=options.get("disable_negative_production", False),
-        disable_installer_account_use=options.get("disable_installer_account_use", False),
+        disable_installer_account_use=options.get(DISABLE_INSTALLER_ACCOUNT_USE,config[DISABLE_INSTALLER_ACCOUNT_USE]),
     )
     await envoy_reader._sync_store()
 

--- a/custom_components/enphase_envoy/config_flow.py
+++ b/custom_components/enphase_envoy/config_flow.py
@@ -26,6 +26,7 @@ from .const import (
     CONF_SERIAL,
     DEFAULT_SCAN_INTERVAL,
     DEFAULT_REALTIME_UPDATE_THROTTLE,
+    DISABLE_INSTALLER_ACCOUNT_USE,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -41,6 +42,7 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> EnvoyRead
         enlighten_pass=data[CONF_PASSWORD],
         inverters=False,
         enlighten_serial_num=data[CONF_SERIAL],
+        disable_installer_account_use=data[DISABLE_INSTALLER_ACCOUNT_USE],
     )
 
     try:
@@ -79,6 +81,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         schema[vol.Required(CONF_SERIAL, default=self.unique_id)] = str
         schema[vol.Required(CONF_USERNAME, default=self.username)] = str
         schema[vol.Required(CONF_PASSWORD, default="")] = str
+        schema[vol.Required(DISABLE_INSTALLER_ACCOUNT_USE, default=False)] = bool
 
         return vol.Schema(schema)
 
@@ -240,10 +243,11 @@ class EnvoyOptionsFlowHandler(config_entries.OptionsFlow):
                 ),
             ): vol.All(vol.Coerce(int), vol.Range(min=0)),
             vol.Optional(
-                "disable_installer_account_use",
-                default=self.config_entry.options.get(
-                    "disable_installer_account_use", False
-                ),
+                DISABLE_INSTALLER_ACCOUNT_USE,
+                default=(self.config_entry.options.get(
+                    DISABLE_INSTALLER_ACCOUNT_USE, 
+                    self.config_entry.data.get(DISABLE_INSTALLER_ACCOUNT_USE,False)
+                )),
             ): bool,
         }
         return self.async_show_form(step_id="user", data_schema=vol.Schema(schema))

--- a/custom_components/enphase_envoy/config_flow.py
+++ b/custom_components/enphase_envoy/config_flow.py
@@ -231,7 +231,6 @@ class EnvoyOptionsFlowHandler(config_entries.OptionsFlow):
                     "disable_negative_production", False
                 ),
             ): bool,
-
             vol.Optional(
                 "enable_realtime_updates",
                 default=self.config_entry.options.get("enable_realtime_updates", False),
@@ -244,10 +243,14 @@ class EnvoyOptionsFlowHandler(config_entries.OptionsFlow):
             ): vol.All(vol.Coerce(int), vol.Range(min=0)),
             vol.Optional(
                 DISABLE_INSTALLER_ACCOUNT_USE,
-                default=(self.config_entry.options.get(
-                    DISABLE_INSTALLER_ACCOUNT_USE, 
-                    self.config_entry.data.get(DISABLE_INSTALLER_ACCOUNT_USE,False)
-                )),
+                default=(
+                    self.config_entry.options.get(
+                        DISABLE_INSTALLER_ACCOUNT_USE,
+                        self.config_entry.data.get(
+                            DISABLE_INSTALLER_ACCOUNT_USE, False
+                        ),
+                    )
+                ),
             ): bool,
         }
         return self.async_show_form(step_id="user", data_schema=vol.Schema(schema))

--- a/custom_components/enphase_envoy/config_flow.py
+++ b/custom_components/enphase_envoy/config_flow.py
@@ -228,6 +228,7 @@ class EnvoyOptionsFlowHandler(config_entries.OptionsFlow):
                     "disable_negative_production", False
                 ),
             ): bool,
+
             vol.Optional(
                 "enable_realtime_updates",
                 default=self.config_entry.options.get("enable_realtime_updates", False),
@@ -238,6 +239,12 @@ class EnvoyOptionsFlowHandler(config_entries.OptionsFlow):
                     "realtime_update_throttle", DEFAULT_REALTIME_UPDATE_THROTTLE
                 ),
             ): vol.All(vol.Coerce(int), vol.Range(min=0)),
+            vol.Optional(
+                "disable_installer_account_use",
+                default=self.config_entry.options.get(
+                    "disable_installer_account_use", False
+                ),
+            ): bool,
         }
         return self.async_show_form(step_id="user", data_schema=vol.Schema(schema))
 

--- a/custom_components/enphase_envoy/const.py
+++ b/custom_components/enphase_envoy/const.py
@@ -36,6 +36,7 @@ DEFAULT_REALTIME_UPDATE_THROTTLE = 10
 CONF_SERIAL = "serial"
 
 LIVE_UPDATEABLE_ENTITIES = "live-update-entities"
+DISABLE_INSTALLER_ACCOUNT_USE = "disable_installer_account_use"
 
 SENSORS = (
     SensorEntityDescription(

--- a/custom_components/enphase_envoy/envoy_reader.py
+++ b/custom_components/enphase_envoy/envoy_reader.py
@@ -141,6 +141,7 @@ class EnvoyReader:
         token_refresh_buffer_seconds=0,
         store=None,
         disable_negative_production=False,
+        disable_installer_account_use=False,
     ):
         """Init the EnvoyReader."""
         self.host = host.lower()
@@ -175,6 +176,7 @@ class EnvoyReader:
         except ipaddress.AddressValueError:
             pass
         self.disable_negative_production = disable_negative_production
+        self.disable_installer_account_use = disable_installer_account_use
 
         self.is_receiving_realtime_data = False
 
@@ -239,14 +241,17 @@ class EnvoyReader:
 
     async def _update_from_installer_endpoint(self):
         """Update from installer endpoint."""
-        await self._update_endpoint(
-            "endpoint_devstatus", ENDPOINT_URL_DEVSTATUS, only_on_success=True
+        if not self.disable_installer_account_use:
+            await self._update_endpoint(
+                "endpoint_devstatus", ENDPOINT_URL_DEVSTATUS, only_on_success=True
+            )
+            await self._update_endpoint(
+                "endpoint_production_power",
+                ENDPOINT_URL_PRODUCTION_POWER,
+                only_on_success=True
         )
-        await self._update_endpoint(
-            "endpoint_production_power",
-            ENDPOINT_URL_PRODUCTION_POWER,
-            only_on_success=True,
-        )
+        else:
+            _LOGGER.debug("Disable installer account use : %s ",self.disable_installer_account_use)
 
     async def _update_endpoint(self, attr, url, only_on_success=False):
         """Update a property from an endpoint."""

--- a/custom_components/enphase_envoy/envoy_reader.py
+++ b/custom_components/enphase_envoy/envoy_reader.py
@@ -248,10 +248,13 @@ class EnvoyReader:
             await self._update_endpoint(
                 "endpoint_production_power",
                 ENDPOINT_URL_PRODUCTION_POWER,
-                only_on_success=True
-        )
+                only_on_success=True,
+            )
         else:
-            _LOGGER.debug("Disable installer account use : %s ",self.disable_installer_account_use)
+            _LOGGER.debug(
+                "Disable installer account use : %s ",
+                self.disable_installer_account_use,
+            )
 
     async def _update_endpoint(self, attr, url, only_on_success=False):
         """Update a property from an endpoint."""

--- a/custom_components/enphase_envoy/strings.json
+++ b/custom_components/enphase_envoy/strings.json
@@ -8,7 +8,8 @@
           "host": "[%key:common::config_flow::data::host%]",
           "username": "[%key:common::config_flow::data::username%]",
           "password": "[%key:common::config_flow::data::password%]",
-          "serial": "Envoy Serial Number"
+          "serial": "Envoy Serial Number",
+          "disable_installer_account_use": "I have no installer or DIY enphase account, just Home owner"
         }
       }
     },

--- a/custom_components/enphase_envoy/strings.json
+++ b/custom_components/enphase_envoy/strings.json
@@ -30,7 +30,8 @@
           "enable_realtime_updates": "Enable realtime updates (only for metered envoys)",
           "realtime_update_throttle": "Minimum time between realtime entity updates [s]",
           "disable_negative_production": "Disable negative production values",
-          "time_between_update": "Minimum time between entity updates [s]"
+          "time_between_update": "Minimum time between entity updates [s]",
+          "disable_installer_account_use": "Do not collect data that requires installer or DIY enphase account"
         },
         "data_description": {
           "realtime_update_throttle": "Only applies to realtime updates (to preventing any overload on the system)",

--- a/custom_components/enphase_envoy/translations/en.json
+++ b/custom_components/enphase_envoy/translations/en.json
@@ -16,7 +16,8 @@
           "host": "Host",
           "password": "Enlighten Password",
           "username": "Enlighten Username",
-          "serial": "Envoy Serial Number"
+          "serial": "Envoy Serial Number",
+          "disable_installer_account_use": "I have no installer or DIY enphase account, just Home owner"
         },
         "description": "Enter the hostname/ip and serial of your Envoy. Use your Enlighten Installer account credentials."
       }

--- a/custom_components/enphase_envoy/translations/en.json
+++ b/custom_components/enphase_envoy/translations/en.json
@@ -30,7 +30,8 @@
           "enable_realtime_updates": "Enable realtime updates (only for metered envoys)",
           "realtime_update_throttle": "Minimum time between realtime entity updates [s]",
           "disable_negative_production": "Disable negative production values",
-          "time_between_update": "Minimum time between entity updates [s]"
+          "time_between_update": "Minimum time between entity updates [s]",
+          "disable_installer_account_use": "Do not collect data that requires installer or DIY enphase account"
         },
         "data_description": {
           "realtime_update_throttle": "Only applies to realtime updates (to preventing any overload on the system)",

--- a/custom_components/enphase_envoy/translations/nl.json
+++ b/custom_components/enphase_envoy/translations/nl.json
@@ -16,7 +16,8 @@
                     "host": "Host",
                     "password": "Enlighten Wachtwoord",
                     "username": "Enlighten Gebruikersnaam",
-                    "serial": "Envoy Serienummer"
+                    "serial": "Envoy Serienummer",
+                    "disable_installer_account_use": "Ik heb geen installer of DHZ enphase account, alleen Home owner"
                 },
                 "description": "Voer de hostname/ip en serienummer van je Envoy in. Gebruik je Enlighten installer account gegevens."
             }

--- a/custom_components/enphase_envoy/translations/nl.json
+++ b/custom_components/enphase_envoy/translations/nl.json
@@ -31,6 +31,7 @@
             "enable_realtime_updates": "Gebruik real-time updates (werkt alleen met metered envoys)",
             "realtime_update_throttle": "Minimale tijd tussen real-time updates [s]",
             "disable_negative_production": "Voorkom negatieve productie waardes",
+            "time_between_update": "Minimum tijd tussen entity updates [s]",
             "disable_installer_account_use": "Haal geen data op die een installateur of DHZ enphase account vereisen"
           },
           "data_description": {

--- a/custom_components/enphase_envoy/translations/nl.json
+++ b/custom_components/enphase_envoy/translations/nl.json
@@ -30,7 +30,7 @@
             "enable_realtime_updates": "Gebruik real-time updates (werkt alleen met metered envoys)",
             "realtime_update_throttle": "Minimale tijd tussen real-time updates [s]",
             "disable_negative_production": "Voorkom negatieve productie waardes",
-            "time_between_update": "Minimum tijd tussen entity updates [s]"
+            "disable_installer_account_use": "Haal geen data op die een installateur of DHZ enphase account vereisen"
           },
           "data_description": {
             "realtime_update_throttle": "Dit interval is van toepassing op real-time updates (om eventuele overload met updates te voorkomen)",


### PR DESCRIPTION
This option allows to not collect data that requires authorization through a installer or DIY account. Enabling the option will prevent repeated new enphase token collection and still have resulting 401 status from the envoy as latest firmware does not allow home owner account access to installer data.

When the integration is configured go to the configuration options, check the 'Do not collect data that requires installer or DIY enphase account' option and reload the integration.