### PR TITLE
Get relay information from inventory if not existing in device status to support Home owner account

### DIFF
--- a/custom_components/enphase_envoy/envoy_reader.py
+++ b/custom_components/enphase_envoy/envoy_reader.py
@@ -1183,7 +1183,7 @@ class EnvoyReader:
                                     )
                                 else:
                                     dev[field] = value
-            except (JSONDecodeError,KeyError, IndexError, TypeError, AttributeError):
+            except (JSONDecodeError, KeyError, IndexError, TypeError, AttributeError):
                 return None
         else:
             return None


### PR DESCRIPTION
Get relay information from inventory if not existing in device status. Home Owner account users have no access to device status in newer firmware. Only missing information is the forced field. 