### PR TITLE
Updated envoy_reader with smarter fetching and fetching properties based on jsonpaths

### DIFF
--- a/custom_components/enphase_envoy/test_data/envoy_metered/endpoint_consumption_report.json
+++ b/custom_components/enphase_envoy/test_data/envoy_metered/endpoint_consumption_report.json
@@ -1,0 +1,74 @@
+[
+    {
+        "createdAt": 1689258576,
+        "reportType": "total-consumption",
+        "cumulative": {
+            "currW": 3366.363,
+            "actPower": 3366.363,
+            "apprntPwr": 3381.996,
+            "reactPwr": 277.693,
+            "whDlvdCum": 1820885.806,
+            "whRcvdCum": 0.000,
+            "varhLagCum": -374044.619,
+            "varhLeadCum": -0.042,
+            "vahCum": 0.000,
+            "rmsVoltage": 248.937,
+            "rmsCurrent": 13.586,
+            "pwrFactor": 1.00,
+            "freqHz": 50.00
+        },
+        "lines": [
+            {
+                "currW": 3366.363,
+                "actPower": 3366.363,
+                "apprntPwr": 3381.996,
+                "reactPwr": 277.693,
+                "whDlvdCum": 1820885.806,
+                "whRcvdCum": 0.000,
+                "varhLagCum": -374044.619,
+                "varhLeadCum": -0.042,
+                "vahCum": 0.000,
+                "rmsVoltage": 248.937,
+                "rmsCurrent": 13.586,
+                "pwrFactor": 1.00,
+                "freqHz": 50.00
+            }
+        ]
+    },
+    {
+        "createdAt": 1689258576,
+        "reportType": "net-consumption",
+        "cumulative": {
+            "currW": 0.000,
+            "actPower": 0.000,
+            "apprntPwr": 0.000,
+            "reactPwr": -0.000,
+            "whDlvdCum": 0.000,
+            "whRcvdCum": 0.000,
+            "varhLagCum": 0.000,
+            "varhLeadCum": 0.000,
+            "vahCum": 0.000,
+            "rmsVoltage": 248.937,
+            "rmsCurrent": 0.000,
+            "pwrFactor": 0.00,
+            "freqHz": 50.00
+        },
+        "lines": [
+            {
+                "currW": 0.000,
+                "actPower": 0.000,
+                "apprntPwr": 0.000,
+                "reactPwr": -0.000,
+                "whDlvdCum": 0.000,
+                "whRcvdCum": 0.000,
+                "varhLagCum": 0.000,
+                "varhLeadCum": 0.000,
+                "vahCum": 0.000,
+                "rmsVoltage": 248.937,
+                "rmsCurrent": 0.000,
+                "pwrFactor": 0.00,
+                "freqHz": 50.00
+            }
+        ]
+    }
+]

--- a/custom_components/enphase_envoy/test_data/envoy_metered/endpoint_devstatus.json
+++ b/custom_components/enphase_envoy/test_data/envoy_metered/endpoint_devstatus.json
@@ -1,0 +1,330 @@
+{
+    "counters": {
+        "pcu": {
+            "expected": 14,
+            "discovered": 14,
+            "ctrlsTotal": 14,
+            "ctrlsGone": 0,
+            "ctrlsCommunicating": 14,
+            "chansTotal": 14,
+            "chansRecent": 14,
+            "chansProducing": 14
+        },
+        "acb": {
+            "expected": 0,
+            "discovered": 0,
+            "ctrlsTotal": 0,
+            "ctrlsGone": 0,
+            "ctrlsCommunicating": 0,
+            "chansTotal": 0,
+            "chansRecent": 0,
+            "chansProducing": 0
+        },
+        "nsrb": {
+            "expected": 2,
+            "discovered": 2,
+            "ctrlsTotal": 2,
+            "ctrlsGone": 0,
+            "ctrlsCommunicating": 2,
+            "chansTotal": 2,
+            "chansRecent": 2,
+            "chansProducing": 0
+        },
+        "pld": {
+            "expected": 16,
+            "discovered": 16,
+            "ctrlsTotal": 16,
+            "ctrlsGone": 0,
+            "ctrlsCommunicating": 16,
+            "chansTotal": 16,
+            "chansRecent": 16,
+            "chansProducing": 14
+        },
+        "esub": {
+            "expected": 0,
+            "discovered": 0,
+            "ctrlsTotal": 0,
+            "ctrlsGone": 0,
+            "ctrlsCommunicating": 0,
+            "chansTotal": 0,
+            "chansRecent": 0,
+            "chansProducing": 0
+        }
+    },
+    "pcu": {
+        "fields": [
+            "serialNumber",
+            "devType",
+            "communicating",
+            "recent",
+            "producing",
+            "reportDate",
+            "temperature",
+            "dcVoltageINmV",
+            "dcCurrentINmA",
+            "acVoltageINmV",
+            "acPowerINmW"
+        ],
+        "values": [
+            [
+                "999999913010",
+                1,
+                true,
+                true,
+                true,
+                1689258553,
+                39,
+                30765,
+                8335,
+                250528,
+                251832
+            ],
+            [
+                "999999913012",
+                1,
+                true,
+                true,
+                true,
+                1689258403,
+                36,
+                31038,
+                8656,
+                249832,
+                229937
+            ],
+            [
+                "999999912750",
+                1,
+                true,
+                true,
+                true,
+                1689258555,
+                36,
+                32317,
+                6985,
+                250448,
+                223379
+            ],
+            [
+                "999999912983",
+                1,
+                true,
+                true,
+                true,
+                1689258584,
+                38,
+                30913,
+                8127,
+                249792,
+                253993
+            ],
+            [
+                "999999908520",
+                1,
+                true,
+                true,
+                true,
+                1689258526,
+                38,
+                30636,
+                9655,
+                248816,
+                289102
+            ],
+            [
+                "999999909983",
+                1,
+                true,
+                true,
+                true,
+                1689258313,
+                35,
+                30958,
+                9958,
+                251840,
+                218666
+            ],
+            [
+                "999999908521",
+                1,
+                true,
+                true,
+                true,
+                1689258526,
+                36,
+                30631,
+                9592,
+                249280,
+                286456
+            ],
+            [
+                "999999912669",
+                1,
+                true,
+                true,
+                true,
+                1689258285,
+                35,
+                32625,
+                9471,
+                250024,
+                220724
+            ],
+            [
+                "999999913748",
+                1,
+                true,
+                true,
+                true,
+                1689258586,
+                37,
+                30578,
+                9555,
+                249968,
+                287450
+            ],
+            [
+                "999999909985",
+                1,
+                true,
+                true,
+                true,
+                1689258284,
+                36,
+                31243,
+                9895,
+                249616,
+                211995
+            ],
+            [
+                "999999915285",
+                1,
+                true,
+                true,
+                true,
+                1689258345,
+                35,
+                32662,
+                9374,
+                251808,
+                244714
+            ],
+            [
+                "999999915246",
+                1,
+                true,
+                true,
+                true,
+                1689258405,
+                35,
+                31637,
+                9738,
+                250976,
+                259065
+            ],
+            [
+                "999999912590",
+                1,
+                true,
+                true,
+                true,
+                1689258344,
+                33,
+                34254,
+                2976,
+                251560,
+                99668
+            ],
+            [
+                "999999910862",
+                1,
+                true,
+                true,
+                true,
+                1689258285,
+                29,
+                31524,
+                1776,
+                249928,
+                51092
+            ],
+            [
+                "999999968177",
+                12,
+                true,
+                true,
+                false,
+                1689258314,
+                0,
+                0,
+                0,
+                0,
+                0
+            ],
+            [
+                "999999935944",
+                12,
+                true,
+                true,
+                false,
+                1689258315,
+                0,
+                0,
+                0,
+                0,
+                0
+            ]
+        ]
+    },
+    "acb": {
+        "fields": [
+            "serialNumber",
+            "SOC",
+            "minCellTemp",
+            "maxCellTemp",
+            "capacity",
+            "totVoltage",
+            "sleepEnabled",
+            "sleepMinSoc",
+            "sleepMaxSoc"
+        ],
+        "values": []
+    },
+    "nsrb": {
+        "fields": [
+            "serialNumber",
+            "relay",
+            "forced",
+            "reason_code",
+            "reason",
+            "line-count",
+            "line1-connected",
+            "line2-connected",
+            "line3-connected"
+        ],
+        "values": [
+            [
+                "999999968177",
+                "closed",
+                false,
+                -1,
+                "ok",
+                1,
+                true,
+                false,
+                false
+            ],
+            [
+                "999999935944",
+                "closed",
+                false,
+                -1,
+                "ok",
+                1,
+                true,
+                false,
+                false
+            ]
+        ]
+    }
+}

--- a/custom_components/enphase_envoy/test_data/envoy_metered/endpoint_home_json_results.json
+++ b/custom_components/enphase_envoy/test_data/envoy_metered/endpoint_home_json_results.json
@@ -1,0 +1,81 @@
+{
+    "software_build_epoch": 1687430621,
+    "timezone": "Europe/Amsterdam",
+    "current_date": "07/13/2023",
+    "current_time": "16:30",
+    "network": {
+        "web_comm": true,
+        "ever_reported_to_enlighten": true,
+        "last_enlighten_report_time": 1689258312,
+        "primary_interface": "wlan0",
+        "interfaces": [
+            {
+                "type": "ethernet",
+                "interface": "eth0",
+                "mac": "FA:FE:FD:7C:AE:9D",
+                "dhcp": true,
+                "ip": "169.254.120.1",
+                "signal_strength": 0,
+                "signal_strength_max": 1,
+                "carrier": false
+            },
+            {
+                "signal_strength": 3,
+                "signal_strength_max": 5,
+                "type": "wifi",
+                "interface": "wlan0",
+                "mac": "FA:FE:FD:CE:3B:31",
+                "dhcp": true,
+                "ip": "192.168.123.105",
+                "carrier": true,
+                "supported": true,
+                "present": true,
+                "configured": true,
+                "status": "connected"
+            }
+        ]
+    },
+    "tariff": "time_of_use",
+    "comm": {
+        "num": 16,
+        "level": 5,
+        "pcu": {
+            "num": 14,
+            "level": 5
+        },
+        "acb": {
+            "num": 0,
+            "level": 0
+        },
+        "nsrb": {
+            "num": 2,
+            "level": 5
+        },
+        "esub": {
+            "num": 0,
+            "level": 0
+        },
+        "encharge": [
+            {
+                "num": 0,
+                "level": 0,
+                "level_24g": 0,
+                "level_subg": 0
+            }
+        ]
+    },
+    "wireless_connection": [
+        {
+            "signal_strength": 0,
+            "signal_strength_max": 0,
+            "type": "zigbee",
+            "connected": false
+        },
+        {
+            "signal_strength": 0,
+            "signal_strength_max": 0,
+            "type": "subghz",
+            "connected": false
+        }
+    ]
+}

--- a/custom_components/enphase_envoy/test_data/envoy_metered/endpoint_info_results.xml
+++ b/custom_components/enphase_envoy/test_data/envoy_metered/endpoint_info_results.xml
@@ -1,0 +1,85 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<envoy_info>
+  <time>1689258636</time>
+  <device>
+    <sn>999999900879</sn>
+    <pn>800-00654-r08</pn>
+    <software>D7.6.175</software>
+    <euaid>4c8675</euaid>
+    <seqnum>0</seqnum>
+    <apiver>1</apiver>
+    <imeter>true</imeter>
+  </device>
+  <web-tokens>true</web-tokens>
+  <package name='rootfs'>
+    <pn>500-00001-r01</pn>
+    <version>02.00.00</version>
+    <build>1210</build>
+  </package>
+  <package name='kernel'>
+    <pn>500-00011-r02</pn>
+    <version>04.04.225</version>
+    <build>3eb4d3</build>
+  </package>
+  <package name='boot'>
+    <pn>590-00019-r01</pn>
+    <version>02.00.01</version>
+    <build>1f421b</build>
+  </package>
+  <package name='app'>
+    <pn>500-00002-r01</pn>
+    <version>07.06.175</version>
+    <build>f79c8d</build>
+  </package>
+  <package name='devimg'>
+    <pn>500-00005-r01</pn>
+    <version>01.02.371</version>
+    <build>373aab</build>
+  </package>
+  <package name='geo'>
+    <pn>500-00008-r01</pn>
+    <version>02.01.24</version>
+    <build>a74d96</build>
+  </package>
+  <package name='backbone'>
+    <pn>500-00010-r01</pn>
+    <version>07.00.20</version>
+    <build>176d57</build>
+  </package>
+  <package name='meter'>
+    <pn>500-00013-r01</pn>
+    <version>03.02.08</version>
+    <build>eaa252</build>
+  </package>
+  <package name='agf'>
+    <pn>500-00012-r01</pn>
+    <version>02.02.00</version>
+    <build>40061a</build>
+  </package>
+  <package name='essimg'>
+    <pn>500-00020-r01</pn>
+    <version>21.19.82</version>
+    <build>667fd7</build>
+  </package>
+  <package name='security'>
+    <pn>500-00016-r01</pn>
+    <version>02.00.00</version>
+    <build>54a6dc</build>
+  </package>
+  <package name='pkgsec'>
+    <pn>500-00021-r01</pn>
+    <version>01.00.00</version>
+    <build>19ae14</build>
+  </package>
+  <package name='full'>
+    <pn>500-00001-r01</pn>
+    <version>02.00.00</version>
+    <build>1210</build>
+  </package>
+  <build_info>
+    <build_id>ec2-user-envoy_uber-pkg_master:pkg-Jun-22-23-18:55:22</build_id>
+    <build_time_gmt>1687460237</build_time_gmt>
+    <release_ver>02.00.4238</release_ver>
+    <release_stage>700-GA</release_stage>
+  </build_info>
+</envoy_info>

--- a/custom_components/enphase_envoy/test_data/envoy_metered/endpoint_inventory_results.json
+++ b/custom_components/enphase_envoy/test_data/envoy_metered/endpoint_inventory_results.json
@@ -1,0 +1,434 @@
+[
+    {
+        "type": "PCU",
+        "devices": [
+            {
+                "part_num": "800-01736-r02",
+                "installed": "1670744318",
+                "serial_num": "999999913010",
+                "device_status": [
+                    "envoy.global.ok"
+                ],
+                "last_rpt_date": "1689258554",
+                "admin_state": 2,
+                "dev_type": 1,
+                "created_date": "1670744318",
+                "img_load_date": "1613405093",
+                "img_pnum_running": "520-00082-r01-v04.27.04",
+                "ptpn": "540-00135-r01-v04.27.10",
+                "chaneid": 9999990225,
+                "device_control": [
+                    {
+                        "gficlearset": false
+                    }
+                ],
+                "producing": true,
+                "communicating": true,
+                "provisioned": true,
+                "operating": false
+            },
+            {
+                "part_num": "800-01736-r02",
+                "installed": "1670744318",
+                "serial_num": "999999913012",
+                "device_status": [
+                    "envoy.global.ok"
+                ],
+                "last_rpt_date": "1689258404",
+                "admin_state": 2,
+                "dev_type": 1,
+                "created_date": "1670744318",
+                "img_load_date": "1613405093",
+                "img_pnum_running": "520-00082-r01-v04.27.04",
+                "ptpn": "540-00135-r01-v04.27.10",
+                "chaneid": 9999990481,
+                "device_control": [
+                    {
+                        "gficlearset": false
+                    }
+                ],
+                "producing": true,
+                "communicating": true,
+                "provisioned": true,
+                "operating": false
+            },
+            {
+                "part_num": "800-01736-r02",
+                "installed": "1670744318",
+                "serial_num": "999999912750",
+                "device_status": [
+                    "envoy.global.ok"
+                ],
+                "last_rpt_date": "1689258555",
+                "admin_state": 2,
+                "dev_type": 1,
+                "created_date": "1670744318",
+                "img_load_date": "1613405093",
+                "img_pnum_running": "520-00082-r01-v04.27.04",
+                "ptpn": "540-00135-r01-v04.27.10",
+                "chaneid": 9999990737,
+                "device_control": [
+                    {
+                        "gficlearset": false
+                    }
+                ],
+                "producing": true,
+                "communicating": true,
+                "provisioned": true,
+                "operating": false
+            },
+            {
+                "part_num": "800-01736-r02",
+                "installed": "1670744318",
+                "serial_num": "999999912983",
+                "device_status": [
+                    "envoy.global.ok"
+                ],
+                "last_rpt_date": "1689258584",
+                "admin_state": 2,
+                "dev_type": 1,
+                "created_date": "1670744318",
+                "img_load_date": "1613405093",
+                "img_pnum_running": "520-00082-r01-v04.27.04",
+                "ptpn": "540-00135-r01-v04.27.10",
+                "chaneid": 9999990993,
+                "device_control": [
+                    {
+                        "gficlearset": false
+                    }
+                ],
+                "producing": true,
+                "communicating": true,
+                "provisioned": true,
+                "operating": false
+            },
+            {
+                "part_num": "800-01736-r02",
+                "installed": "1670744319",
+                "serial_num": "999999908520",
+                "device_status": [
+                    "envoy.global.ok"
+                ],
+                "last_rpt_date": "1689258526",
+                "admin_state": 2,
+                "dev_type": 1,
+                "created_date": "1670744319",
+                "img_load_date": "1613405093",
+                "img_pnum_running": "520-00082-r01-v04.27.04",
+                "ptpn": "540-00135-r01-v04.27.10",
+                "chaneid": 9999991249,
+                "device_control": [
+                    {
+                        "gficlearset": false
+                    }
+                ],
+                "producing": true,
+                "communicating": true,
+                "provisioned": true,
+                "operating": false
+            },
+            {
+                "part_num": "800-01736-r02",
+                "installed": "1670744319",
+                "serial_num": "999999909983",
+                "device_status": [
+                    "envoy.global.ok"
+                ],
+                "last_rpt_date": "1689258644",
+                "admin_state": 2,
+                "dev_type": 1,
+                "created_date": "1670744319",
+                "img_load_date": "1613405093",
+                "img_pnum_running": "520-00082-r01-v04.27.04",
+                "ptpn": "540-00135-r01-v04.27.10",
+                "chaneid": 9999991505,
+                "device_control": [
+                    {
+                        "gficlearset": false
+                    }
+                ],
+                "producing": true,
+                "communicating": true,
+                "provisioned": true,
+                "operating": false
+            },
+            {
+                "part_num": "800-01736-r02",
+                "installed": "1670744319",
+                "serial_num": "999999908521",
+                "device_status": [
+                    "envoy.global.ok"
+                ],
+                "last_rpt_date": "1689258615",
+                "admin_state": 2,
+                "dev_type": 1,
+                "created_date": "1670744319",
+                "img_load_date": "1613405093",
+                "img_pnum_running": "520-00082-r01-v04.27.04",
+                "ptpn": "540-00135-r01-v04.27.10",
+                "chaneid": 9999991761,
+                "device_control": [
+                    {
+                        "gficlearset": false
+                    }
+                ],
+                "producing": true,
+                "communicating": true,
+                "provisioned": true,
+                "operating": false
+            },
+            {
+                "part_num": "800-01736-r02",
+                "installed": "1670744319",
+                "serial_num": "999999912669",
+                "device_status": [
+                    "envoy.global.ok"
+                ],
+                "last_rpt_date": "1689258617",
+                "admin_state": 2,
+                "dev_type": 1,
+                "created_date": "1670744319",
+                "img_load_date": "1613405093",
+                "img_pnum_running": "520-00082-r01-v04.27.04",
+                "ptpn": "540-00135-r01-v04.27.10",
+                "chaneid": 9999992017,
+                "device_control": [
+                    {
+                        "gficlearset": false
+                    }
+                ],
+                "producing": true,
+                "communicating": true,
+                "provisioned": true,
+                "operating": false
+            },
+            {
+                "part_num": "800-01736-r02",
+                "installed": "1670744319",
+                "serial_num": "999999913748",
+                "device_status": [
+                    "envoy.global.ok"
+                ],
+                "last_rpt_date": "1689258619",
+                "admin_state": 2,
+                "dev_type": 1,
+                "created_date": "1670744319",
+                "img_load_date": "1613405093",
+                "img_pnum_running": "520-00082-r01-v04.27.04",
+                "ptpn": "540-00135-r01-v04.27.10",
+                "chaneid": 9999992273,
+                "device_control": [
+                    {
+                        "gficlearset": false
+                    }
+                ],
+                "producing": true,
+                "communicating": true,
+                "provisioned": true,
+                "operating": false
+            },
+            {
+                "part_num": "800-01736-r02",
+                "installed": "1670744319",
+                "serial_num": "999999909985",
+                "device_status": [
+                    "envoy.global.ok"
+                ],
+                "last_rpt_date": "1689258620",
+                "admin_state": 2,
+                "dev_type": 1,
+                "created_date": "1670744319",
+                "img_load_date": "1613405093",
+                "img_pnum_running": "520-00082-r01-v04.27.04",
+                "ptpn": "540-00135-r01-v04.27.10",
+                "chaneid": 9999992529,
+                "device_control": [
+                    {
+                        "gficlearset": false
+                    }
+                ],
+                "producing": true,
+                "communicating": true,
+                "provisioned": true,
+                "operating": false
+            },
+            {
+                "part_num": "800-01736-r02",
+                "installed": "1670744319",
+                "serial_num": "999999915285",
+                "device_status": [
+                    "envoy.global.ok"
+                ],
+                "last_rpt_date": "1689258345",
+                "admin_state": 2,
+                "dev_type": 1,
+                "created_date": "1670744319",
+                "img_load_date": "1613405093",
+                "img_pnum_running": "520-00082-r01-v04.27.04",
+                "ptpn": "540-00135-r01-v04.27.10",
+                "chaneid": 9999992785,
+                "device_control": [
+                    {
+                        "gficlearset": false
+                    }
+                ],
+                "producing": true,
+                "communicating": true,
+                "provisioned": true,
+                "operating": false
+            },
+            {
+                "part_num": "800-01736-r02",
+                "installed": "1670744320",
+                "serial_num": "999999915246",
+                "device_status": [
+                    "envoy.global.ok"
+                ],
+                "last_rpt_date": "1689258405",
+                "admin_state": 2,
+                "dev_type": 1,
+                "created_date": "1670744320",
+                "img_load_date": "1613405093",
+                "img_pnum_running": "520-00082-r01-v04.27.04",
+                "ptpn": "540-00135-r01-v04.27.10",
+                "chaneid": 9999993041,
+                "device_control": [
+                    {
+                        "gficlearset": false
+                    }
+                ],
+                "producing": true,
+                "communicating": true,
+                "provisioned": true,
+                "operating": false
+            },
+            {
+                "part_num": "800-01736-r02",
+                "installed": "1670744320",
+                "serial_num": "999999912590",
+                "device_status": [
+                    "envoy.global.ok"
+                ],
+                "last_rpt_date": "1689258346",
+                "admin_state": 2,
+                "dev_type": 1,
+                "created_date": "1670744320",
+                "img_load_date": "1613405093",
+                "img_pnum_running": "520-00082-r01-v04.27.04",
+                "ptpn": "540-00135-r01-v04.27.10",
+                "chaneid": 9999993297,
+                "device_control": [
+                    {
+                        "gficlearset": false
+                    }
+                ],
+                "producing": true,
+                "communicating": true,
+                "provisioned": true,
+                "operating": false
+            },
+            {
+                "part_num": "800-01736-r02",
+                "installed": "1670746114",
+                "serial_num": "999999910862",
+                "device_status": [
+                    "envoy.global.ok"
+                ],
+                "last_rpt_date": "1689258621",
+                "admin_state": 1,
+                "dev_type": 1,
+                "created_date": "1670746114",
+                "img_load_date": "1613405093",
+                "img_pnum_running": "520-00082-r01-v04.27.04",
+                "ptpn": "540-00135-r01-v04.27.10",
+                "chaneid": 9999993553,
+                "device_control": [
+                    {
+                        "gficlearset": false
+                    }
+                ],
+                "producing": true,
+                "communicating": true,
+                "provisioned": true,
+                "operating": false
+            }
+        ]
+    },
+    {
+        "type": "ACB",
+        "devices": []
+    },
+    {
+        "type": "NSRB",
+        "devices": [
+            {
+                "part_num": "800-00598-r04",
+                "installed": "1670706046",
+                "serial_num": "999999968177",
+                "device_status": [
+                    "envoy.global.ok"
+                ],
+                "last_rpt_date": "1689258645",
+                "admin_state": 1,
+                "dev_type": 12,
+                "created_date": "1670706046",
+                "img_load_date": "1522376696",
+                "img_pnum_running": "520-00086-r01-v02.12.07",
+                "ptpn": "540-00139-r01-v02.12.00",
+                "chaneid": 9999999601,
+                "device_control": [
+                    {
+                        "gficlearset": false
+                    }
+                ],
+                "producing": false,
+                "communicating": true,
+                "provisioned": true,
+                "operating": true,
+                "relay": "closed",
+                "reason_code": -1,
+                "reason": "ok",
+                "line-count": 1,
+                "line1-connected": true,
+                "line2-connected": false,
+                "line3-connected": false
+            },
+            {
+                "part_num": "800-00598-r04",
+                "installed": "1671018504",
+                "serial_num": "999999935944",
+                "device_status": [
+                    "envoy.global.ok"
+                ],
+                "last_rpt_date": "1689258646",
+                "admin_state": 1,
+                "dev_type": 12,
+                "created_date": "1671018504",
+                "img_load_date": "1522376696",
+                "img_pnum_running": "520-00086-r01-v02.12.07",
+                "ptpn": "540-00139-r01-v02.12.00",
+                "chaneid": 9999999857,
+                "device_control": [
+                    {
+                        "gficlearset": false
+                    }
+                ],
+                "producing": false,
+                "communicating": true,
+                "provisioned": true,
+                "operating": true,
+                "relay": "closed",
+                "reason_code": -1,
+                "reason": "ok",
+                "line-count": 1,
+                "line1-connected": true,
+                "line2-connected": false,
+                "line3-connected": false
+            }
+        ]
+    },
+    {
+        "type": "ESUB",
+        "devices": []
+    }
+]

--- a/custom_components/enphase_envoy/test_data/envoy_metered/endpoint_production_inverters.json
+++ b/custom_components/enphase_envoy/test_data/envoy_metered/endpoint_production_inverters.json
@@ -1,0 +1,100 @@
+[
+    {
+        "serialNumber": "999999913010",
+        "lastReportDate": 1689258553,
+        "devType": 1,
+        "lastReportWatts": 252,
+        "maxReportWatts": 297
+    },
+    {
+        "serialNumber": "999999913012",
+        "lastReportDate": 1689258403,
+        "devType": 1,
+        "lastReportWatts": 230,
+        "maxReportWatts": 297
+    },
+    {
+        "serialNumber": "999999912750",
+        "lastReportDate": 1689258555,
+        "devType": 1,
+        "lastReportWatts": 223,
+        "maxReportWatts": 297
+    },
+    {
+        "serialNumber": "999999912983",
+        "lastReportDate": 1689258584,
+        "devType": 1,
+        "lastReportWatts": 254,
+        "maxReportWatts": 297
+    },
+    {
+        "serialNumber": "999999908520",
+        "lastReportDate": 1689258525,
+        "devType": 1,
+        "lastReportWatts": 289,
+        "maxReportWatts": 297
+    },
+    {
+        "serialNumber": "999999909983",
+        "lastReportDate": 1689258644,
+        "devType": 1,
+        "lastReportWatts": 276,
+        "maxReportWatts": 297
+    },
+    {
+        "serialNumber": "999999908521",
+        "lastReportDate": 1689258526,
+        "devType": 1,
+        "lastReportWatts": 286,
+        "maxReportWatts": 297
+    },
+    {
+        "serialNumber": "999999912669",
+        "lastReportDate": 1689258618,
+        "devType": 1,
+        "lastReportWatts": 291,
+        "maxReportWatts": 297
+    },
+    {
+        "serialNumber": "999999913748",
+        "lastReportDate": 1689258586,
+        "devType": 1,
+        "lastReportWatts": 287,
+        "maxReportWatts": 297
+    },
+    {
+        "serialNumber": "999999909985",
+        "lastReportDate": 1689258619,
+        "devType": 1,
+        "lastReportWatts": 283,
+        "maxReportWatts": 297
+    },
+    {
+        "serialNumber": "999999915285",
+        "lastReportDate": 1689258345,
+        "devType": 1,
+        "lastReportWatts": 245,
+        "maxReportWatts": 297
+    },
+    {
+        "serialNumber": "999999915246",
+        "lastReportDate": 1689258405,
+        "devType": 1,
+        "lastReportWatts": 259,
+        "maxReportWatts": 297
+    },
+    {
+        "serialNumber": "999999912590",
+        "lastReportDate": 1689258344,
+        "devType": 1,
+        "lastReportWatts": 100,
+        "maxReportWatts": 297
+    },
+    {
+        "serialNumber": "999999910862",
+        "lastReportDate": 1689258620,
+        "devType": 1,
+        "lastReportWatts": 46,
+        "maxReportWatts": 297
+    }
+]

--- a/custom_components/enphase_envoy/test_data/envoy_metered/endpoint_production_json_results.json
+++ b/custom_components/enphase_envoy/test_data/envoy_metered/endpoint_production_json_results.json
@@ -1,0 +1,143 @@
+{
+    "production": [
+        {
+            "type": "inverters",
+            "activeCount": 14,
+            "readingTime": 1689258464,
+            "wNow": 2642,
+            "whLifetime": 836653
+        },
+        {
+            "type": "eim",
+            "activeCount": 1,
+            "measurementType": "production",
+            "readingTime": 1689258508,
+            "wNow": 3441.236,
+            "whLifetime": 1820822.12,
+            "varhLeadLifetime": 0.042,
+            "varhLagLifetime": 374039.343,
+            "vahLifetime": 2007531.058,
+            "rmsCurrent": 14.012,
+            "rmsVoltage": 248.393,
+            "reactPwr": 282.206,
+            "apprntPwr": 3481.322,
+            "pwrFactor": 0.99,
+            "whToday": 21430.12,
+            "whLastSevenDays": 199376.12,
+            "vahToday": 23359.058,
+            "varhLeadToday": 0.042,
+            "varhLagToday": 4001.343,
+            "lines": [
+                {
+                    "wNow": 3441.236,
+                    "whLifetime": 1820822.12,
+                    "varhLeadLifetime": 0.042,
+                    "varhLagLifetime": 374039.343,
+                    "vahLifetime": 2007531.058,
+                    "rmsCurrent": 14.012,
+                    "rmsVoltage": 248.393,
+                    "reactPwr": 282.206,
+                    "apprntPwr": 3481.322,
+                    "pwrFactor": 0.99,
+                    "whToday": 21430.12,
+                    "whLastSevenDays": 199376.12,
+                    "vahToday": 23359.058,
+                    "varhLeadToday": 0.042,
+                    "varhLagToday": 4001.343
+                }
+            ]
+        }
+    ],
+    "consumption": [
+        {
+            "type": "eim",
+            "activeCount": 0,
+            "measurementType": "total-consumption",
+            "readingTime": 1689258508,
+            "wNow": 3441.236,
+            "whLifetime": 1820822.12,
+            "varhLeadLifetime": -0.042,
+            "varhLagLifetime": -374039.343,
+            "vahLifetime": 0.0,
+            "rmsCurrent": 14.012,
+            "rmsVoltage": 248.339,
+            "reactPwr": 282.206,
+            "apprntPwr": 3479.79,
+            "pwrFactor": 0.99,
+            "whToday": 1820822.12,
+            "whLastSevenDays": 1820822.12,
+            "vahToday": 0.0,
+            "varhLeadToday": 0.0,
+            "varhLagToday": 0.0,
+            "lines": [
+                {
+                    "wNow": 3441.236,
+                    "whLifetime": 1820822.12,
+                    "varhLeadLifetime": -0.042,
+                    "varhLagLifetime": -374039.343,
+                    "vahLifetime": 0.0,
+                    "rmsCurrent": 14.012,
+                    "rmsVoltage": 248.339,
+                    "reactPwr": 282.206,
+                    "apprntPwr": 3479.79,
+                    "pwrFactor": 0.99,
+                    "whToday": 1820822.12,
+                    "whLastSevenDays": 1820822.12,
+                    "vahToday": 0.0,
+                    "varhLeadToday": 0.0,
+                    "varhLagToday": 0.0
+                }
+            ]
+        },
+        {
+            "type": "eim",
+            "activeCount": 0,
+            "measurementType": "net-consumption",
+            "readingTime": 1689258508,
+            "wNow": 0.0,
+            "whLifetime": 0.0,
+            "varhLeadLifetime": 0.0,
+            "varhLagLifetime": 0.0,
+            "vahLifetime": 0.0,
+            "rmsCurrent": 0.0,
+            "rmsVoltage": 248.339,
+            "reactPwr": -0.0,
+            "apprntPwr": 0.0,
+            "pwrFactor": 0.0,
+            "whToday": 0,
+            "whLastSevenDays": 0,
+            "vahToday": 0,
+            "varhLeadToday": 0,
+            "varhLagToday": 0,
+            "lines": [
+                {
+                    "wNow": 0.0,
+                    "whLifetime": 0.0,
+                    "varhLeadLifetime": 0.0,
+                    "varhLagLifetime": 0.0,
+                    "vahLifetime": 0.0,
+                    "rmsCurrent": 0.0,
+                    "rmsVoltage": 248.339,
+                    "reactPwr": -0.0,
+                    "apprntPwr": 0.0,
+                    "pwrFactor": 0.0,
+                    "whToday": 0,
+                    "whLastSevenDays": 0,
+                    "vahToday": 0,
+                    "varhLeadToday": 0,
+                    "varhLagToday": 0
+                }
+            ]
+        }
+    ],
+    "storage": [
+        {
+            "type": "acb",
+            "activeCount": 0,
+            "readingTime": 0,
+            "wNow": 0,
+            "whNow": 0,
+            "state": "idle"
+        }
+    ]
+}

--- a/custom_components/enphase_envoy/test_data/envoy_metered/endpoint_production_power.json
+++ b/custom_components/enphase_envoy/test_data/envoy_metered/endpoint_production_power.json
@@ -1,0 +1,3 @@
+{
+    "powerForcedOff": false
+}

--- a/custom_components/enphase_envoy/test_data/envoy_metered/endpoint_production_report.json
+++ b/custom_components/enphase_envoy/test_data/envoy_metered/endpoint_production_report.json
@@ -1,0 +1,36 @@
+{
+    "createdAt": 1689258566,
+    "reportType": "production",
+    "cumulative": {
+        "currW": 3366.764,
+        "actPower": 3366.764,
+        "apprntPwr": 3406.287,
+        "reactPwr": 283.013,
+        "whDlvdCum": 1820876.754,
+        "whRcvdCum": 3513.299,
+        "varhLagCum": 374043.865,
+        "varhLeadCum": 0.042,
+        "vahCum": 2007586.298,
+        "rmsVoltage": 248.761,
+        "rmsCurrent": 13.691,
+        "pwrFactor": 0.99,
+        "freqHz": 50.00
+    },
+    "lines": [
+        {
+            "currW": 3366.764,
+            "actPower": 3366.764,
+            "apprntPwr": 3406.287,
+            "reactPwr": 283.013,
+            "whDlvdCum": 1820876.754,
+            "whRcvdCum": 3513.299,
+            "varhLagCum": 374043.865,
+            "varhLeadCum": 0.042,
+            "vahCum": 2007586.298,
+            "rmsVoltage": 248.761,
+            "rmsCurrent": 13.691,
+            "pwrFactor": 0.99,
+            "freqHz": 50.00
+        }
+    ]
+}

--- a/custom_components/enphase_envoy/test_data/envoy_metered/endpoint_production_v1_results.json
+++ b/custom_components/enphase_envoy/test_data/envoy_metered/endpoint_production_v1_results.json
@@ -1,0 +1,6 @@
+{
+    "wattHoursToday": 21515,
+    "wattHoursSevenDays": 198717,
+    "wattHoursLifetime": 1820907,
+    "wattsNow": 3185
+}


### PR DESCRIPTION
And other updates:
- URL's are registered in a mapping, with some additional settings, like how often to fetch the url and if installer token is required
- The JWT token has a field for identifying the type of the token (owner or installer). This is now implemented in determining if we can fetch a url endpoint.
- Attributes can be referenced with jsonpath logic or be defined by @envoy_property wrappers. This way it is easier to add new measurements and also easier to differentiate between EnvoyStandard and Metered and Metered with CT.
- Because of the jsonpath logic, we can also use the non-None properties to get a list of endpoints we should update. Which urls are required are evaluated once, when one full getData call has completed.

I also included test data, so we can more easily test the EnvoyData parser, without waiting for output of the envoy, so it is easier to test the jsonpath values.