### PR TITLE
Envoy reader use session and fixate loading the store from HA upon init.

### DIFF
--- a/custom_components/enphase_envoy/__init__.py
+++ b/custom_components/enphase_envoy/__init__.py
@@ -73,7 +73,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             config.get(DISABLE_INSTALLER_ACCOUNT_USE, False),
         ),
     )
-    await envoy_reader._sync_store()
+    await envoy_reader._sync_store(load=True)
 
     async def async_update_data():
         """Fetch data from API endpoint."""

--- a/custom_components/enphase_envoy/envoy_reader.py
+++ b/custom_components/enphase_envoy/envoy_reader.py
@@ -482,6 +482,17 @@ class EnvoyReader:
         if token_validation.status_code == 200:
             # set the cookies for future clients
             self._cookies = token_validation.cookies
+
+            # search for all cookies with session in the name (sessionId, session_id, etc)
+            session_cookies = [k for k in self._cookies if "session" in k.lower()]
+            if len(session_cookies) > 0:
+                # We have a session id, so let's drop the auth header
+                # to prevent any lookups for authentication (if any)
+                _LOGGER.debug(
+                    "We got a session cookie (%s), empty the auth header",
+                    ",".join(session_cookies),
+                )
+                self._authorization_header = {}
             return True
 
         # token not valid if we get here

--- a/custom_components/enphase_envoy/envoy_reader.py
+++ b/custom_components/enphase_envoy/envoy_reader.py
@@ -193,8 +193,8 @@ class EnvoyReader:
         self._store_data["token"] = token_value
         self._store_update_pending = True
 
-    async def _sync_store(self):
-        if self._store and not self._store_data:
+    async def _sync_store(self, load=False):
+        if (self._store and not self._store_data) or load:
             self._store_data = await self._store.async_load() or {}
 
         if self._store and self._store_update_pending:


### PR DESCRIPTION
- Force loading the store from home assistant, when called from HA
> When testing it makes sense to store a token in self.data (to prevent fetching a new token, thus causing too many installer sessions on the envoy). Since tokens are stored in HA, we should keep using this token, eventhough we might have configured something else in envoy_reader.py


- Lets not send the auth_header every time, and use the cookie's session id
> Not sure if the auth header calls entrez every time, but since we're already authenticated, it would make sense to not send the bearer token on every request.