### PR TITLE
Remove the static icon, as the device_class already defines a icon in HA

### DIFF
--- a/custom_components/enphase_envoy/binary_sensor.py
+++ b/custom_components/enphase_envoy/binary_sensor.py
@@ -5,7 +5,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.helpers.entity import DeviceInfo
 
-from .const import COORDINATOR, DOMAIN, NAME, ICON, BINARY_SENSORS
+from .const import COORDINATOR, DOMAIN, NAME, BINARY_SENSORS
 
 
 async def async_setup_entry(
@@ -102,11 +102,6 @@ class EnvoyGridStatusEntity(CoordinatorEntity, BinarySensorEntity):
         CoordinatorEntity.__init__(self, coordinator)
 
     @property
-    def icon(self):
-        """Icon to use in the frontend, if any."""
-        return ICON
-
-    @property
     def name(self):
         """Return the name of the sensor."""
         return self._name
@@ -153,11 +148,6 @@ class EnvoyInverterEntity(CoordinatorEntity, BinarySensorEntity):
         self._device_name = device_name
         self._device_serial_number = device_serial_number
         CoordinatorEntity.__init__(self, coordinator)
-
-    @property
-    def icon(self):
-        """Icon to use in the frontend, if any."""
-        return ICON
 
     @property
     def name(self):
@@ -250,11 +240,6 @@ class EnvoyBaseEntity(CoordinatorEntity):
     def native_value(self):
         """Return the state of the sensor."""
         return self.coordinator.data.get(self.entity_description.key)
-
-    @property
-    def icon(self):
-        """Icon to use in the frontend, if any."""
-        return ICON
 
     @property
     def extra_state_attributes(self):

--- a/custom_components/enphase_envoy/const.py
+++ b/custom_components/enphase_envoy/const.py
@@ -24,8 +24,6 @@ DOMAIN = "enphase_envoy"
 
 PLATFORMS = [Platform.SENSOR, Platform.BINARY_SENSOR, Platform.SWITCH]
 
-ICON = "mdi:flash"
-
 COORDINATOR = "coordinator"
 NAME = "name"
 READER = "reader"

--- a/custom_components/enphase_envoy/const.py
+++ b/custom_components/enphase_envoy/const.py
@@ -103,6 +103,7 @@ SENSORS = (
     SensorEntityDescription(
         key="inverters_dc_current",
         name="DC Current",
+        icon="mdi:current-dc",
         native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.CURRENT,

--- a/custom_components/enphase_envoy/sensor.py
+++ b/custom_components/enphase_envoy/sensor.py
@@ -21,7 +21,6 @@ from .const import (
     DOMAIN,
     NAME,
     SENSORS,
-    ICON,
     PHASE_SENSORS,
     LIVE_UPDATEABLE_ENTITIES,
 )
@@ -210,11 +209,6 @@ class EnvoyEntity(SensorEntity):
             return f"{self._device_serial_number}_{self.entity_description.key}"
 
     @property
-    def icon(self):
-        """Icon to use in the frontend, if any."""
-        return ICON
-
-    @property
     def extra_state_attributes(self):
         """Return the state attributes."""
         return None
@@ -292,11 +286,6 @@ class EnvoyInverterEntity(CoordinatorEntity, SensorEntity):
     def name(self):
         """Return the name of the sensor."""
         return self._name
-
-    @property
-    def icon(self):
-        """Icon to use in the frontend, if any."""
-        return ICON
 
     @property
     def unique_id(self):

--- a/custom_components/enphase_envoy/switch.py
+++ b/custom_components/enphase_envoy/switch.py
@@ -5,7 +5,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.helpers.entity import DeviceInfo
 
-from .const import COORDINATOR, DOMAIN, NAME, ICON, PRODUCION_POWER_SWITCH, READER
+from .const import COORDINATOR, DOMAIN, NAME, PRODUCION_POWER_SWITCH, READER
 
 
 async def async_setup_entry(
@@ -54,11 +54,6 @@ class EnvoyProductionSwitchEntity(CoordinatorEntity, SwitchEntity):
         CoordinatorEntity.__init__(self, coordinator)
         self._is_on = False
         self.reader = reader
-
-    @property
-    def icon(self):
-        """Icon to use in the frontend, if any."""
-        return ICON
 
     @property
     def name(self):


### PR DESCRIPTION
Looks way better with different icons based on the device class.

![image](https://github.com/vincentwolsink/home_assistant_enphase_envoy_installer/assets/7044570/20c47c9c-3611-4d35-8bd6-c0bbf604746c)

