### PR TITLE
Adding a product_id mapping to show more information about devices

### DIFF
--- a/custom_components/enphase_envoy/const.py
+++ b/custom_components/enphase_envoy/const.py
@@ -41,6 +41,46 @@ DISABLE_INSTALLER_ACCOUNT_USE = "disable_installer_account_use"
 ENABLE_ADDITIONAL_METRICS = "enable_additional_metrics"
 ADDITIONAL_METRICS = []
 
+PRODUCT_ID_MAPPING = {
+    "800-00598-r04": {"name": "IQ Relay 1-phase", "sku": "Q-RELAY-1P-INT"},
+    "800-00654-r08": {"name": "Envoy-S-Metered-EU", "sku": "ENV-S-WM-230"},
+    "800-00656-r06": {"name": "Envoy-S-Standard-EU", "sku": "ENV-S-WB-230"},
+    "800-01359-r02": {"name": "IQ8+ Microinverter", "sku": "IQ8PLUS-72-M-INT"},
+    "800-01736-r02": {"name": "IQ7+ Microinverter", "sku": "IQ7PLUS-72-M-INT"},
+}
+
+
+def resolve_product_mapping(product_id):
+    if PRODUCT_ID_MAPPING.get(product_id, None) != None:
+        return PRODUCT_ID_MAPPING[product_id]
+
+    def id_iter():
+        yield product_id.rsplit("-", 1)[0]
+        yield product_id.split("-")[1]
+
+    for match in id_iter():
+        for key, product in PRODUCT_ID_MAPPING.items():
+            if key == match or match in key:
+                # Create alias for consecutive calls.
+                PRODUCT_ID_MAPPING[match] = product
+                return product
+
+
+def resolve_hardware_id(hardware_id):
+    info = resolve_product_mapping(hardware_id)
+    if not info:
+        return hardware_id
+
+    return f"{info['sku']} ({hardware_id})"
+
+
+def get_model_name(model, hardware_id):
+    product = resolve_product_mapping(hardware_id)
+    if product:
+        return product["name"]
+    return model
+
+
 SENSORS = (
     SensorEntityDescription(
         key="production",

--- a/custom_components/enphase_envoy/envoy_reader.py
+++ b/custom_components/enphase_envoy/envoy_reader.py
@@ -375,7 +375,7 @@ class EnvoyStandard(EnvoyData):
             "software": self.get("envoy_software"),
             "software_build_epoch": self.get("envoy_software_build_epoch"),
             "update_status": self.get("envoy_update_status_value"),
-            "model": self.reader.endpoint_type,
+            "model": getattr(self, "ALIAS", self.__class__.__name__[5:]),
         }
 
     production_value = path_by_token(
@@ -548,6 +548,8 @@ class EnvoyMetered(EnvoyStandard):
 
 class EnvoyMeteredWithCT(EnvoyMetered):
     """Adds CT based sensors, like current usage per phase"""
+
+    ALIAS = "Metered (with CT)"
 
     def __new__(cls, reader, **kw):
         # Add phase CT production value attributes, as this class is

--- a/custom_components/enphase_envoy/sensor.py
+++ b/custom_components/enphase_envoy/sensor.py
@@ -25,6 +25,8 @@ from .const import (
     LIVE_UPDATEABLE_ENTITIES,
     ENABLE_ADDITIONAL_METRICS,
     ADDITIONAL_METRICS,
+    resolve_hardware_id,
+    get_model_name,
 )
 
 
@@ -263,7 +265,7 @@ class CoordinatedEnvoyEntity(EnvoyEntity, CoordinatorEntity):
             model=f"Envoy-S {model}",
             name=self._device_name,
             sw_version=sw_version,
-            hw_version=hw_version,
+            hw_version=resolve_hardware_id(hw_version),
             configuration_url=f"https://{self.device_host}/"
             if self.device_host
             else None,
@@ -369,11 +371,11 @@ class EnvoyInverterEntity(CoordinatorEntity, SensorEntity):
         return DeviceInfo(
             identifiers={(DOMAIN, str(self._device_serial_number))},
             manufacturer="Enphase",
-            model="Inverter",
+            model=get_model_name("Inverter", hw_version),
             name=self._device_name,
             via_device=(DOMAIN, self._parent_device),
             sw_version=sw_version,
-            hw_version=hw_version,
+            hw_version=resolve_hardware_id(hw_version),
         )
 
 


### PR DESCRIPTION
Not really sure if it is what i expected, but so far it looks like this:

envoy device:
![image](https://github.com/vincentwolsink/home_assistant_enphase_envoy_installer/assets/7044570/1b24267b-346b-4cd4-b7ee-bbf383488855)

inverter device:
![image](https://github.com/vincentwolsink/home_assistant_enphase_envoy_installer/assets/7044570/d1dc5033-8577-4eee-a4dc-34e910887914)

relay device:
![image](https://github.com/vincentwolsink/home_assistant_enphase_envoy_installer/assets/7044570/10cb84bf-3a76-412a-b9d5-97cf6f713ee2)
