### PR TITLE
Fix entity naming (make sure to always include device name)

### DIFF
--- a/custom_components/enphase_envoy/number.py
+++ b/custom_components/enphase_envoy/number.py
@@ -29,10 +29,11 @@ async def async_setup_entry(
         coordinator.data.get("batteries") is not None
         and coordinator.data.get("storage_charge_from_grid") is not None
     ):
+        entity_name = f"{name} {STORAGE_RESERVE_SOC_NUMBER.name}"
         entities.append(
             EnvoyStorageReservedSocEntity(
                 STORAGE_RESERVE_SOC_NUMBER,
-                STORAGE_RESERVE_SOC_NUMBER.name,
+                entity_name,
                 name,
                 config_entry.unique_id,
                 None,

--- a/custom_components/enphase_envoy/select.py
+++ b/custom_components/enphase_envoy/select.py
@@ -23,10 +23,11 @@ async def async_setup_entry(
         coordinator.data.get("batteries") is not None
         and coordinator.data.get("storage_mode") is not None
     ):
+        entity_name = f"{name} {STORAGE_MODE_SELECT.name}"
         entities.append(
             EnvoyStorageModeSelectEntity(
                 STORAGE_MODE_SELECT,
-                STORAGE_MODE_SELECT.name,
+                entity_name,
                 name,
                 config_entry.unique_id,
                 None,

--- a/custom_components/enphase_envoy/switch.py
+++ b/custom_components/enphase_envoy/switch.py
@@ -31,10 +31,11 @@ async def async_setup_entry(
                 coordinator.data.get("batteries") is not None
                 and coordinator.data.get(switch_description.key) is not None
             ):
+                entity_name = f"{name} {switch_description.name}"
                 entities.append(
                     EnvoyStorageSwitchEntity(
                         switch_description,
-                        switch_description.name,
+                        entity_name,
                         name,
                         config_entry.unique_id,
                         None,
@@ -44,10 +45,11 @@ async def async_setup_entry(
                 )
         else:
             if coordinator.data.get(switch_description.key) is not None:
+                entity_name = f"{name} {switch_description.name}"
                 entities.append(
                     EnvoySwitchEntity(
                         switch_description,
-                        switch_description.name,
+                        entity_name,
                         name,
                         config_entry.unique_id,
                         None,


### PR DESCRIPTION
Some enitites where missing Envoy and serial in the name. This could cause issues when multiple Envoys are present.