### PR TITLE
Add the MAC addresses of the Envoy to the DeviceInfo connections

### DIFF
--- a/custom_components/enphase_envoy/envoy_reader.py
+++ b/custom_components/enphase_envoy/envoy_reader.py
@@ -21,6 +21,7 @@ from json.decoder import JSONDecodeError
 
 from .envoy_endpoints import (
     ENDPOINT_URL_INFO_XML,
+    ENDPOINT_URL_HOME_JSON,
     ENDPOINT_URL_PRODUCTION_JSON,
     ENDPOINT_URL_PRODUCTION_V1,
     ENDPOINT_URL_PRODUCTION_INVERTERS,
@@ -375,12 +376,16 @@ class EnvoyStandard(EnvoyData):
     serial_number_value = "endpoint_info.envoy_info.device.sn"
     grid_profile_value = "endpoint_installer_agf.selected_profile"
     grid_profiles_available_value = "endpoint_installer_agf.profiles"
+    ethernet_mac_address_value = "endpoint_home_json.network.interfaces[?(@.type==\"ethernet\")].mac"
+    wifi_mac_address_value = "endpoint_home_json.network.interfaces[?(@.type==\"wifi\")].mac"
 
     @envoy_property()
     def envoy_info(self):
         return {
             "pn": self.get("envoy_pn"),
             "software": self.get("envoy_software"),
+            "ethernet_mac_address": self.get("ethernet_mac_address"),
+            "wifi_mac_address": self.get("wifi_mac_address"),
             "model": getattr(self, "ALIAS", self.__class__.__name__[5:]),
         }
 
@@ -676,6 +681,7 @@ class EnvoyReader:
         iurl = partial(url, installer_required="installer")
 
         self.uri_registry = {}
+        url("home_json", ENDPOINT_URL_HOME_JSON, cache=86400)
         url("production_json", ENDPOINT_URL_PRODUCTION_JSON, cache=0)
         url("production_v1", ENDPOINT_URL_PRODUCTION_V1, cache=20)
         url("production_inverters", ENDPOINT_URL_PRODUCTION_INVERTERS, cache=20)

--- a/custom_components/enphase_envoy/sensor.py
+++ b/custom_components/enphase_envoy/sensor.py
@@ -6,6 +6,7 @@ from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -256,7 +257,15 @@ class CoordinatedEnvoyEntity(EnvoyEntity, CoordinatorEntity):
 
         sw_version = self.coordinator.data.get("envoy_info", {}).get("software", None)
         hw_version = self.coordinator.data.get("envoy_info", {}).get("pn", None)
+        ethernet_mac_address = self.coordinator.data.get("envoy_info", {}).get("ethernet_mac_address", None)
+        wifi_mac_address = self.coordinator.data.get("envoy_info", {}).get("wifi_mac_address", None)
         model = self.coordinator.data.get("envoy_info", {}).get("model", "Standard")
+
+        connections = set()
+        if ethernet_mac_address:
+            connections.add((CONNECTION_NETWORK_MAC, ethernet_mac_address))
+        if wifi_mac_address:
+            connections.add((CONNECTION_NETWORK_MAC, wifi_mac_address))
 
         return DeviceInfo(
             identifiers={(DOMAIN, str(self._device_serial_number))},
@@ -265,6 +274,7 @@ class CoordinatedEnvoyEntity(EnvoyEntity, CoordinatorEntity):
             name=self._device_name,
             sw_version=sw_version,
             hw_version=resolve_hardware_id(hw_version),
+            connections=connections,
             configuration_url=(
                 f"https://{self.device_host}/" if self.device_host else None
             ),


### PR DESCRIPTION
This change makes it easier for Home Assistant to merge entities from different integrations that belong to the same device.

Let me know if this is an acceptable addition or if I need to change anything. 

