### PR TITLE
Only retry on unauthorized or http exception. On all other error codes return empty.

### DIFF
--- a/custom_components/enphase_envoy/envoy_reader.py
+++ b/custom_components/enphase_envoy/envoy_reader.py
@@ -770,7 +770,7 @@ class EnvoyReader:
                         received_401 += 1
                         continue
                     _LOGGER.debug("Fetched from %s: %s: %s", url, resp, resp.text)
-                    if resp.status_code == 404:
+                    if resp.status_code != 200:
                         return None
                     return resp
             except httpx.TransportError as e:


### PR DESCRIPTION
With all the extra endpoints and slow Envoys in the field doing multiple (mostly useless) retries will just exceed the max fetch time and break the whole integration.