### PR TITLE
Keep information about production values

### DIFF
--- a/custom_components/enphase_envoy/sensor.py
+++ b/custom_components/enphase_envoy/sensor.py
@@ -392,6 +392,8 @@ class EnvoyInverterEntity(EnvoyDeviceEntity):
                     return datetime.datetime.fromtimestamp(
                         int(value), tz=datetime.timezone.utc
                     )
+                if self.entity_description.name.endswith("Production"):
+                    return value
                 if serial.get("gone", True):
                     return None
                 return value


### PR DESCRIPTION
Information like:
- Lifetime energy Production
- This week energy Production
- Todays Energy Production
- Yesterdays Energy Production
- Production itself

Then, when the inverter is offline, we keep seeing these values:
![image](https://github.com/user-attachments/assets/547b93b0-bbe9-419d-b58e-4a096ebcfa03)
