### PR TITLE
Revert "Revert "Remove AC Current sensor, no correct readings""

### DIFF
--- a/custom_components/enphase_envoy/const.py
+++ b/custom_components/enphase_envoy/const.py
@@ -184,14 +184,6 @@ SENSORS = (
         suggested_display_precision=3,
     ),
     InverterSensorEntityDescription(
-        key="inverter_data_ac_current",
-        name="AC Current",
-        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
-        state_class=SensorStateClass.MEASUREMENT,
-        device_class=SensorDeviceClass.CURRENT,
-        suggested_display_precision=3,
-    ),
-    InverterSensorEntityDescription(
         key="inverter_data_dc_voltage",
         name="DC Voltage",
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,


### PR DESCRIPTION
I think you were right to remove it the first time 😄 

My assumption is that this value is only used, if the inverter is used to charge a battery. In my setup it is always 0, but as the name in the file says, it is acCurrentInmA (so inbound).

One var that might be a nice to have, it the leadingVArs, which is the reactive power in the inverter while producing power.
My assumption is, that laggingVArs is the value for reactive power while in charging mode

Maybe if somebody shares their file with a battery setup, it might shed some more light on those assumptions 😇 

Reverts vincentwolsink/home_assistant_enphase_envoy_installer#181