### PR TITLE
use correct tower icon for exporting

### DIFF
--- a/custom_components/enphase_envoy/const.py
+++ b/custom_components/enphase_envoy/const.py
@@ -771,7 +771,8 @@ BINARY_SENSORS = (
     BinarySensorEntityDescription(
         key="dpel_enabled",
         name="Dynamic Power Export Limiting",
-        icon="mdi:transmission-tower-export",
+        # 'tower-import' icon means 'sending power to grid'
+        icon="mdi:transmission-tower-import",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
 )


### PR DESCRIPTION
These icons can be confusingly named. See https://pictogrammers.com/library/mdi/icon/transmission-tower-import/, that describes this icon as 'power-to-grid' and 'return-to-grid'. The name is from the grid's point of view - it is the grid that is importing. From our point of view though, we are exporting.

So to refer to 'export to grid', we need to use the 'tower-import' icon.