### PR TITLE
Try alternative token retrieval method

### DIFF
--- a/custom_components/enphase_envoy/envoy_reader.py
+++ b/custom_components/enphase_envoy/envoy_reader.py
@@ -33,6 +33,9 @@ ENLIGHTEN_LOGIN_URL = "https://entrez.enphaseenergy.com/login"
 ENDPOINT_URL_GET_JWT = "https://{}/auth/get_jwt"
 ENDPOINT_URL_CHECK_JWT = "https://{}/auth/check_jwt"
 
+ENLIGHTEN_AUTH_URL = "https://enlighten.enphaseenergy.com/login/login.json?"
+ENLIGHTEN_TOKEN_URL = "https://entrez.enphaseenergy.com/tokens"
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -966,6 +969,36 @@ class EnvoyReader:
             _LOGGER.debug("TransportError: %s", e)
             raise e
 
+    async def _fetch_enlighten_token_json(self):
+        """
+        Try to fetch the token json from Enlighten API
+        :return:
+        """
+        _LOGGER.debug("Fetching enlighten token")
+        async with self.async_client as client:
+            # login to Enlighten
+            payload_login = {
+                "user[email]": self.enlighten_user,
+                "user[password]": self.enlighten_pass,
+            }
+            resp = await client.post(ENLIGHTEN_AUTH_URL, data=payload_login, timeout=30)
+            if resp.status_code >= 400:
+                raise EnlightenError("Could not Authenticate via Enlighten")
+
+            # now that we're in a logged in session, we can request the installer token
+            login_data = resp.json()
+            payload_token = {
+                "session_id": login_data["session_id"],
+                "serial_num": self.enlighten_serial_num,
+                "username": self.enlighten_user,
+            }
+            resp = await client.post(
+                ENLIGHTEN_TOKEN_URL, json=payload_token, timeout=30
+            )
+            if resp.status_code != 200:
+                raise EnlightenError("Could not get enlighten token")
+            return resp.text
+
     async def _fetch_envoy_token_json(self):
         """
         Fetch a token, using the same procedure envoy uses in the webUI
@@ -1035,7 +1068,7 @@ class EnvoyReader:
             return resp.json()["access_token"]
 
     async def _get_enphase_token(self):
-        self._token = await self._fetch_envoy_token_json()
+        self._token = await self._fetch_enlighten_token_json()
 
         _LOGGER.debug("Envoy Token")
         if self._is_enphase_token_expired(self._token):


### PR DESCRIPTION
Since the old method seems to fail on newer firmwares. There have been some issues with not getting a proper installer token using this method. So we need to see how it does.