### PR TITLE
Missing mapping from API call for Watt and Export_limit handling in async_enable_dpel

### DIFF
--- a/custom_components/enphase_envoy/__init__.py
+++ b/custom_components/enphase_envoy/__init__.py
@@ -153,11 +153,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
 
     async def async_enable_dpel(call: ServiceCall):
+        watt = call.data.get("watt")
+        export_limit = call.data.get("export_limit", True)
+        
         await envoy_reader.enable_dpel(
             watt=call.data.get("watt"),
             slew=call.data.get("slew_rate", 50),
             export_limit=call.data.get("export_limit", True),
         )
+        
+        coordinator.data["dpel_limit"] = watt
+        coordinator.data["dpel_mode"] = "export" if export_limit else "production"
+        
         await coordinator.async_request_refresh()
 
     hass.services.async_register(DOMAIN, "enable_dpel", async_enable_dpel)


### PR DESCRIPTION
Retrieve watt and export_limit from service call data for enabling DPEL sensors in Home Assistant to show/display and report correct values on actual retrieved DPEL limit value and type from enphase envoy. 

This change basically fixes and adds 2 sensors to the diagnose sensors.  To report back the actual value of the DPEL in watt and the value of the export_limit, true/false. False means, limitations are applied on production perspective of Enphase Envoy only. 

action: enphase_envoy.enable_dpel
data:
  watt: 1000
  slew_rate: 100
  export_limit: false

Handige toevoeging, naast alleen DPEL actief aan/uit.