### PR TITLE
Fix data fetch breaking on jsonpath namespace collision (TypeError: 'module' object is not callable)

### DIFF
--- a/custom_components/enphase_envoy/envoy_reader.py
+++ b/custom_components/enphase_envoy/envoy_reader.py
@@ -11,7 +11,6 @@ import ipaddress
 import json
 import re
 
-from jsonpath import jsonpath
 from json.decoder import JSONDecodeError
 
 from .envoy_endpoints import (
@@ -34,6 +33,39 @@ ENLIGHTEN_TOKEN_URL = "https://entrez.enphaseenergy.com/tokens"
 ENDPOINT_URL_CHECK_JWT = "https://{}/auth/check_jwt"
 
 _LOGGER = logging.getLogger(__name__)
+
+
+# Token = a dict key  OR  a [n] list index.
+_JSONPATH_TOKEN = re.compile(r"([^.\[\]]+)|\[(\d+)\]")
+
+
+def jsonpath(obj, path):
+    """Resolve a simple dotted path (e.g. "channels[0].watts.now") against a
+    nested dict/list structure.
+
+    Replaces the external ``jsonpath`` PyPI package: it shares the ``jsonpath``
+    import name with ``jsonpath-python`` (pulled in transitively by recent Home
+    Assistant cores), so ``from jsonpath import jsonpath`` may resolve to a
+    module instead of the callable, raising ``TypeError: 'module' object is not
+    callable`` and breaking all data fetching. Only the simple key/index paths
+    used by this integration are supported. Returns a single-element list with
+    the matched value, or ``False`` when the path does not resolve (mirroring the
+    subset of the old API this integration relied on).
+    """
+    current = obj
+    for name, index in _JSONPATH_TOKEN.findall(path):
+        if name:
+            if isinstance(current, dict) and name in current:
+                current = current[name]
+            else:
+                return False
+        else:
+            i = int(index)
+            if isinstance(current, (list, tuple)) and -len(current) <= i < len(current):
+                current = current[i]
+            else:
+                return False
+    return [current]
 
 
 def parse_devstatus(data):

--- a/custom_components/enphase_envoy/manifest.json
+++ b/custom_components/enphase_envoy/manifest.json
@@ -8,7 +8,7 @@
   "integration_type": "hub",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/vincentwolsink/home_assistant_enphase_envoy_installer/issues",
-  "requirements": ["pyjwt", "xmltodict", "httpx", "jsonpath"],
+  "requirements": ["pyjwt", "xmltodict", "httpx"],
   "version": "0.8.10",
   "zeroconf": ["_enphase-envoy._tcp.local."]
 }


### PR DESCRIPTION
## Problem

On 2026.7b1 the integration stops fetching and all entities go unavailable, with the coordinator logging:

```
ERROR (MainThread) [custom_components.enphase_envoy] Unexpected error fetching envoy ... data
  File ".../envoy_reader.py", line 410, in _resolve_path
    result = jsonpath(self.data, path)
TypeError: 'module' object is not callable
```

### Root cause

`manifest.json` requires the `jsonpath` PyPI package, and `envoy_reader.py` does `from jsonpath import jsonpath` expecting a **callable**. That import name is shared with **`jsonpath-python`**, which recent HA cores pull in transitively. When `jsonpath-python` wins the shared environment, `from jsonpath import jsonpath` resolves to a **submodule** instead of the function, so every `jsonpath(...)` call raises `TypeError: 'module' object is not callable`. It fails in `detect_model()` (`endpoint_info.envoy_info.device.imeter`), which runs for every model, so it affects metered and non-metered units alike.

## Fix

Drop the external `jsonpath` dependency and vendor a tiny resolver. The integration only ever calls `jsonpath()` with **simple dotted key/index paths** (e.g. `channels[0].watts.now`, `endpoint_info.envoy_info.device.imeter`) — no wildcards, filters or recursion — so a ~15-line resolver fully preserves behaviour (single-element list on match, `False` otherwise) while removing the dependency, and the namespace collision, entirely.

- `envoy_reader.py`: remove `from jsonpath import jsonpath`, add vendored `jsonpath()` (both call sites unchanged).
- `manifest.json`: drop `jsonpath` from `requirements`.

## Testing

Applied to a live **non-metered (Standard)** Envoy on HA 2026.7 beta: the `TypeError` is gone, the coordinator fetches cleanly, and `sensor.envoy_current_power_production` resumed reporting. `python -m py_compile` passes.

🤖 Generated with help from [Claude Code](https://claude.com/claude-code)