### PR TITLE
Add IQ8AC mapping to const.py

### DIFF
--- a/custom_components/enphase_envoy/const.py
+++ b/custom_components/enphase_envoy/const.py
@@ -68,6 +68,7 @@ PRODUCT_ID_MAPPING = {
     "800-01359": {"name": "IQ8+ Microinverter", "sku": "IQ8PLUS-72-M-INT"},
     "800-01361": {"name": "IQ8M Microinverter", "sku": "IQ8M-72-M-INT"},
     "800-01391": {"name": "IQ8HC Microinverter", "sku": "IQ8HC-72-M-INT"},
+    "800-01395": {"name": "IQ8AC Microinverter", "sku": "IQ8AC-72-M-INT"},
     "800-01396": {"name": "IQ8MC Microinverter", "sku": "IQ8MC-72-M-INT"},
     "800-01736": {"name": "IQ7+ Microinverter", "sku": "IQ7PLUS-72-M-INT"},
     "800-00631": {"name": "IQ7+ Microinverter", "sku": "IQ7PLUS-72-2-INT"},


### PR DESCRIPTION
I noticed the IQ8AC hasn't been defined yet, so I'd like to add it.
<img width="440" height="120" alt="image" src="https://github.com/user-attachments/assets/2d94cb05-e60c-4a2e-8a45-a9352359bd74" />

<img width="299" height="215" alt="image" src="https://github.com/user-attachments/assets/6f6bf885-5215-43f5-bee7-d1ae0c17b817" />
